### PR TITLE
Release 2.8.0

### DIFF
--- a/.claude/agent-memory/lt-dev-npm-package-maintainer/MEMORY.md
+++ b/.claude/agent-memory/lt-dev-npm-package-maintainer/MEMORY.md
@@ -8,3 +8,4 @@
 - [oxfmt/oxlint latest pin](feedback_oxfmt_oxlint_latest_pin.md) — oxfmt/oxlint now pinned exactly (0.28.0/1.43.0); do NOT bump — newer versions reformat docs and break the gate
 - [Project Structure](project_structure.md) — Two-level package.json structure: root (create-nuxt-base) + nuxt-base-template/; npm-mode peer contract
 - [CHANGELOG .prettierignore](project_changelog_format.md) — Root CHANGELOG.md is generated; excluded from oxfmt via .prettierignore
+- [pnpm 11 auto-exclude](feedback_pnpm11_auto_minimum_release_age.md) — `pnpm add` auto-appends to `minimumReleaseAgeExclude` for fresh versions including transitives; expected, not a bug

--- a/.claude/agent-memory/lt-dev-npm-package-maintainer/feedback_pnpm11_auto_minimum_release_age.md
+++ b/.claude/agent-memory/lt-dev-npm-package-maintainer/feedback_pnpm11_auto_minimum_release_age.md
@@ -1,0 +1,16 @@
+---
+name: pnpm11-auto-minimum-release-age-exclude
+description: pnpm 11 auto-appends to minimumReleaseAgeExclude when adding fresh versions; expect noisy diffs and clean up transitives
+metadata:
+  type: feedback
+---
+
+When running `pnpm add -E pkg@version` in `nuxt-base-template/`, pnpm 11.1.3 auto-appends entries to `minimumReleaseAgeExclude` in `pnpm-workspace.yaml` for every package whose release age is below the "minimumReleaseAge" threshold. This includes ALL same-version transitives — not just the direct dep being bumped.
+
+**Why:** Observed 2026-05-31 during a routine patch bump (`better-auth 1.6.11 → 1.6.13`). pnpm added NINE entries (`@better-auth/core@1.6.13`, `@better-auth/drizzle-adapter@1.6.13`, `@better-auth/kysely-adapter@1.6.13`, `@better-auth/memory-adapter@1.6.13`, `@better-auth/mongo-adapter@1.6.13`, `@better-auth/passkey@1.6.13`, `@better-auth/prisma-adapter@1.6.13`, `@better-auth/telemetry@1.6.13`, `better-auth@1.6.13`) for a single user-facing 2-patch bump. Similar happens for any same-day npm release. Output line: `Added N entries to minimumReleaseAgeExclude in pnpm-workspace.yaml (loose mode allowed these immature versions)`.
+
+**How to apply:**
+- This is expected pnpm 11 behavior, not a bug — leave the entries in place for the duration of the maintenance run so install stays reproducible.
+- Stale exclude entries from PREVIOUS sessions (e.g. `@lenne.tech/nuxt-extensions@1.7.1`) should be reviewed during cleanup — if the targeted version is now past the minimumReleaseAge window (default 7 days), the entry is dead weight and can be pruned. Don't prune entries added during the CURRENT run.
+- The auto-added entries do NOT need to be reflected in CLAUDE.md's override table — that table is for `overrides:` only, not `minimumReleaseAgeExclude:`.
+- Don't try to disable the auto-add behavior; it's the "loose mode" safety valve that lets pnpm proceed when a fresh release would otherwise be blocked by the age policy.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,50 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [2.8.0](https://github.com/lenneTech/nuxt-base-starter/compare/v2.7.2...v2.8.0) (2026-06-01)
+
+
+### Features
+
+* **ai:** AI assistant UI (chat, settings, admin) for the nest-server AI module ([30df8ba](https://github.com/lenneTech/nuxt-base-starter/commit/30df8baff5a50d816de3b44fa37ea1f917a9527a))
+* **ai:** admin UI for prompt templates and learned hints ([796d7bc](https://github.com/lenneTech/nuxt-base-starter/commit/796d7bc81a75cd629a0ac01a39b977adaebe8e3f))
+* **ai:** let the connection form pick a provider (OpenAI-compatible / Claude CLI) ([1600a0b](https://github.com/lenneTech/nuxt-base-starter/commit/1600a0bf0ca95b7dc9a02d147cb35c1bd53487ac))
+* **ai:** token-usage bar + closing-circle context-window indicator in chat ([3672d7c](https://github.com/lenneTech/nuxt-base-starter/commit/3672d7c9aa4e9f2479fc2df5d96b66fb3fc9b9a2))
+* **ai:** user-facing prompt snippet picker + Vorlagen settings page ([23c698d](https://github.com/lenneTech/nuxt-base-starter/commit/23c698d2eab6798e15c1c76487279e7f401b611a))
+* **ai:** tenant-aware Slots-UI with override/reset + dynamic placeholder helper ([4858fb6](https://github.com/lenneTech/nuxt-base-starter/commit/4858fb681f3a7c4309feb4b53cc2584b96500638))
+* **ai:** token bar shows cumulative per-period usage at every scope ([5e514df](https://github.com/lenneTech/nuxt-base-starter/commit/5e514dfd248ce8756fc5db055b8e56225a596a5f))
+* **ai:** token bar opens a click-popover with all numbers; "Konversation leeren" moved out of the token group ([b4099dd](https://github.com/lenneTech/nuxt-base-starter/commit/b4099dd7c19a61d7cfbe03de0a454ecbbb918e53))
+
+
+### Bug Fixes
+
+* **ai:** admin gating via roles array + meaningful usage badge for unlimited users ([6b8bdfc](https://github.com/lenneTech/nuxt-base-starter/commit/6b8bdfc57e96e0e0f4f015e8c0b508022ef7d65b))
+* **ai:** badge shows the last request's tokens, bar handles cumulative period usage ([8d09258](https://github.com/lenneTech/nuxt-base-starter/commit/8d09258f6453cbd65e7fc97886bdaea9a082a2f7))
+* **ai:** token-bar shows the last request when the limit is the context window ([744fa29](https://github.com/lenneTech/nuxt-base-starter/commit/744fa297f2e115094510eb9f9cdf3dcbc6fb9619))
+* **auth:** capture-phase preventDefault closes the login-form hydration race ([8926130](https://github.com/lenneTech/nuxt-base-starter/commit/89261300aa1621acc451d6fe263ad5388f9297f8))
+* **deps:** remove unused dayjs-nuxt module (Vite optimizeDeps interop break) ([2dee546](https://github.com/lenneTech/nuxt-base-starter/commit/2dee546f246044a8c53d405a62e16b0b9ab43389))
+
+
+### Code Refactoring
+
+* **ai:** rename Snippets→Prompts, Prompt-Templates→Slots in UI; drop global scope ([046930f](https://github.com/lenneTech/nuxt-base-starter/commit/046930f9736f580e200d254d27195f0b5de0603f))
+* **ai:** apply code-review findings (perf, isAdmin dedup, docs, tests, SSR) ([d390396](https://github.com/lenneTech/nuxt-base-starter/commit/d3903962e4f5a5d6cd00cb1b03e1a0e3a8a2e9e8))
+
+
+### Dependencies
+
+* bump @lenne.tech/nuxt-extensions to 1.7.1 + routine patch updates (@better-auth 1.6.13, valibot 1.4.1, @nuxt/ui 4.8.1, vue 3.5.35, lint-staged 17.0.7, @hey-api/openapi-ts 0.97.3, @iconify-json/lucide 1.2.111) ([c489fb9](https://github.com/lenneTech/nuxt-base-starter/commit/c489fb988d44dbdec4b5ecd97e55be771e1a6a63))
+
+
+### Highlights for adopters
+
+* **AI assistant UI.** New chat (`/app/ai`) with SSE streaming, token-bar with click-popover, context-window indicator, prompt picker, placeholder hint sidebar, plus 6 admin pages under `/app/admin/ai/*` (connections, preferences, budgets, audit log, slots, prompt-hints), the user-facing Vorlagen page (`/app/settings/ai-prompts`), and `/app/settings/ai`. Backed by `@lenne.tech/nuxt-extensions` 1.7.x `useLtAi*` composables and the `@lenne.tech/nest-server` 11.26.x AI module.
+* **Auth-form hardening.** Capture-phase `preventDefault` on login + register closes a hydration-race credential-leak window. New `tests/e2e/auth-form-hardening.spec.ts` + `tests/e2e/helpers/safe-form-submit.ts`. **Fork-customized auth pages MUST port this patch — see [migration-guides/2.8.0-ai-module.md](migration-guides/2.8.0-ai-module.md).**
+* **`isAdminUser` utility.** Canonical dual-shape admin check (`role: string` ∪ `roles: string[]`) extracted to `app/utils/is-admin-user.ts`; auto-imported and used by `admin.global.ts`, `layouts/default.vue`, and `pages/app/settings/ai-prompts.vue`. Guarded by `tests/unit/utils/is-admin-user.test.ts` (6 cases).
+* **Migration guide.** Full 2.7 → 2.8 upgrade path at [migration-guides/2.8.0-ai-module.md](migration-guides/2.8.0-ai-module.md).
+* **`ltExtensions.ai`** config block (`{ enabled, basePath }`) added to `nuxt.config.ts`. Set `enabled: false` to opt out of the AI module entirely.
+* **Layout nav** gains four entries for authenticated users: `KI-Assistent`, `KI-Vorlagen`, `KI-Einstellungen`, plus `Administration` (admins only).
+
 ### [2.7.2](https://github.com/lenneTech/nuxt-base-starter/compare/v2.7.1...v2.7.2) (2026-05-24)
 
 ### [2.7.1](https://github.com/lenneTech/nuxt-base-starter/compare/v2.7.0...v2.7.1) (2026-05-24)

--- a/migration-guides/2.8.0-ai-module.md
+++ b/migration-guides/2.8.0-ai-module.md
@@ -1,0 +1,122 @@
+# Migration Guide — 2.7.x → 2.8.0
+
+Version 2.8.0 ships the AI assistant UI on top of the `@lenne.tech/nest-server`
+AI module. For greenfield projects this is fully additive — no action required.
+For forks of the 2.7.x starter that need to take 2.8.0 changes, follow the steps
+below.
+
+## What changed
+
+| Area                    | Change                                                                                        |
+| ----------------------- | --------------------------------------------------------------------------------------------- |
+| Dependencies            | `@lenne.tech/nuxt-extensions` bumped `1.6.x → 1.7.1` (AI composables + sideEffects: false)    |
+| Dependencies            | `better-auth` + `@better-auth/passkey` bumped `1.6.11 → 1.6.13` (security release)            |
+| Dependencies            | `valibot 1.4.1`, `@nuxt/ui 4.8.1`, `vue 3.5.35`, `lint-staged 17.0.7`, plus dev-only patches  |
+| New pages               | `/app/ai`, `/app/settings/ai`, `/app/settings/ai-prompts`, `/app/admin/index`, 6 admin pages  |
+| New components          | `Ai/AiChat`, `AiConnectionPicker`, `AiContextWindow`, `AiMessage`, `AiPlaceholderHint`, `AiPromptPicker`, `AiTokenBar`, `AiUsageBadge`, `ModalAiConnection` |
+| New utility             | `app/utils/is-admin-user.ts` — canonical dual-shape admin check                               |
+| New tests               | `tests/unit/utils/is-admin-user.test.ts`, `tests/e2e/ai.spec.ts`, `tests/e2e/auth-form-hardening.spec.ts`, `tests/e2e/helpers/safe-form-submit.ts` |
+| Config                  | `nuxt.config.ts` gains `ltExtensions.ai: { enabled, basePath }`                               |
+| Layout                  | `app/layouts/default.vue` gains four AI nav entries for authenticated users                   |
+| Security hardening      | `app/pages/auth/login.vue` + `register.vue` attach a **capture-phase `preventDefault`** to close a credential-leak race during hydration |
+| pnpm                    | `pnpm-workspace.yaml` gains a `minimumReleaseAgeExclude` block (auto-managed by pnpm 11)      |
+
+## Upgrade steps (existing 2.7.x fork)
+
+### 1. Bump the package
+
+```bash
+cd nuxt-base-template
+pnpm add @lenne.tech/nuxt-extensions@1.7.1 better-auth@1.6.13 @better-auth/passkey@1.6.13 valibot@1.4.1 @nuxt/ui@4.8.1
+pnpm install
+```
+
+Expect pnpm 11 to auto-add `minimumReleaseAgeExclude` entries for fresh versions.
+Keep them — the policy gives you supply-chain protection. See CLAUDE.md
+"`minimumReleaseAgeExclude`" for the maintenance contract.
+
+### 2. Add the AI module config block
+
+In `nuxt.config.ts`, under `ltExtensions`, add:
+
+```ts
+ai: {
+  enabled: true,    // Set false to opt out (see below).
+  basePath: '/ai',  // Must match the nest-server AI controller mount.
+},
+```
+
+### 3. Decide: opt in or opt out
+
+**Opt in** (most projects): copy `app/components/Ai/`, `app/pages/app/ai/`,
+`app/pages/app/admin/`, `app/pages/app/settings/ai*.vue`, and
+`app/pages/app/admin/index.vue` from the template. Add the four nav entries to
+your `app/layouts/default.vue` (`KI-Assistent`, `KI-Vorlagen`, `KI-Einstellungen`,
+plus `Administration` gated by `isAdminUser(user.value)`).
+
+**Opt out**: set `ltExtensions.ai.enabled: false` in `nuxt.config.ts`. Do NOT copy
+the AI components/pages. Skip the nav entries.
+
+### 4. Port the auth-form race fix — **MANDATORY**
+
+If you customized `app/pages/auth/login.vue` or `app/pages/auth/register.vue` in
+your fork, you MUST port the capture-phase `preventDefault` block from 2.8.0.
+Without it, fast Enter-key submits (Chrome DevTools, Playwright, real users on
+slow hydration) trigger a native form GET that puts the typed password into the
+URL (`/auth/login?email=…&password=…`).
+
+The pattern (in `onMounted`):
+
+```ts
+const form = document.querySelector('form');
+form?.addEventListener('submit', (e) => e.preventDefault(), { capture: true });
+```
+
+Vue's bubble-phase handler still runs once hydrated and performs the SPA sign-in.
+The new test `tests/e2e/auth-form-hardening.spec.ts` guards the contract.
+
+### 5. Adopt the `isAdminUser` helper
+
+If your fork has inline `user?.role === 'admin'` checks, replace them with the
+auto-imported `isAdminUser(user)`. Reason: nest-server users carry roles as an
+array (`roles: string[]`); the old `role === 'admin'` check silently dropped
+every admin and broke admin nav + admin routes.
+
+```ts
+// Before
+if (user.value?.role === 'admin') { ... }
+
+// After
+if (isAdminUser(user.value)) { ... }
+```
+
+Add `app/utils/is-admin-user.ts` from the template (Nuxt auto-imports it).
+
+### 6. Backend pairing
+
+The AI surface needs `@lenne.tech/nest-server 11.26.0+` with the `ai` module
+enabled. Required REST routes:
+
+```
+/ai/prompt          /ai/stream         /ai/connections    /ai/preferences
+/ai/budget-limits   /ai/interactions   /ai/slots          /ai/prompts
+/ai/prompt-hints    /ai/placeholders   /ai/usage          /ai/features
+```
+
+The streaming endpoint flows through the existing `/api` dev proxy — no extra
+nginx / Caddy config needed.
+
+### 7. Verify
+
+```bash
+cd nuxt-base-template
+pnpm run check         # audit + format:check + lint + tests + build + server start
+pnpm run test:e2e      # Playwright (requires API + frontend running)
+```
+
+## Rollback
+
+To roll back to 2.7.x: revert the dependency bumps, remove the `ai` config
+block, delete the AI surface files, and (optionally — but recommended)
+keep the capture-phase preventDefault fix anyway. The fix is a pure
+security improvement that does not depend on the AI module.

--- a/nuxt-base-template/CLAUDE.md
+++ b/nuxt-base-template/CLAUDE.md
@@ -94,6 +94,58 @@ PORT=4011 NUXT_PUBLIC_SITE_URL=https://crm.localhost NUXT_PUBLIC_API_URL=https:/
 | Auth             | `useBetterAuth()` from `@lenne.tech/nuxt-extensions`               |
 | Protected Routes | `middleware: 'auth'` in page `definePageMeta`                      |
 
+## AI Module (since v2.8.0)
+
+The starter ships a full AI assistant UI on top of `@lenne.tech/nuxt-extensions` 1.7.x
+composables (which talk to the `@lenne.tech/nest-server` 11.26.0+ AI module).
+
+**Composables consumed** (auto-imported when `ltExtensions.ai.enabled: true` in `nuxt.config.ts`):
+
+| Composable              | Used by                                                                                                    |
+| ----------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `useLtAiChat()`         | `app/components/Ai/AiChat.vue` — streaming + budget + ctx                                                  |
+| `useLtAiPrompts()`      | `app/components/Ai/AiPromptPicker.vue`, `pages/app/settings/ai-prompts.vue`                                |
+| `useLtAiPlaceholders()` | `app/components/Ai/AiPlaceholderHint.vue`                                                                  |
+| `useLtAiConnections()`  | `app/components/Ai/AiConnectionPicker.vue`, `pages/app/settings/ai.vue`                                    |
+| `useLtAiUsage()`        | `pages/app/settings/ai.vue`                                                                                |
+| `useLtAiAdmin()`        | `pages/app/admin/ai/*.vue` (CRUD for connections, budgets, slots, prompt-hints, preferences, interactions) |
+
+**Config block** (`nuxt.config.ts`):
+
+```ts
+ltExtensions: {
+  ai: {
+    enabled: true,         // Set false to disable the AI module entirely.
+    basePath: '/ai',       // Must match the nest-server AI controller mount point.
+  },
+  // ...
+}
+```
+
+**Performance notes:**
+
+- `AiChat.vue` passes `maxMessages: 100` to `useLtAiChat()` to cap history growth.
+- The auto-scroll watcher source is `[messages.value.length, messages.value.at(-1)?.content]` (O(1) per SSE token); never re-introduce a `messages.map(...).join(...)` source.
+
+## Admin Gating — `isAdminUser`
+
+The project's admin role check has to accept **two shapes** because backend providers
+differ:
+
+- **`role: string`** — Better Auth singular form (default for the standalone Better Auth setup).
+- **`roles: string[]`** — nest-server projection (`AuthService` flattens user roles to an array).
+
+The canonical helper lives in `app/utils/is-admin-user.ts` (auto-imported as `isAdminUser`).
+It is used by every site that gates admin functionality:
+
+- `app/middleware/admin.global.ts` — route guard for `/app/admin/**`
+- `app/layouts/default.vue` — admin nav entry
+- `app/pages/app/settings/ai-prompts.vue` — mutate-foreign-prompt gate
+
+**Rule:** never re-implement the dual-shape check inline. Always import / call
+`isAdminUser(user)`. The Vitest spec at `tests/unit/utils/is-admin-user.test.ts`
+guards the contract (no user / `role:'admin'` / `roles:['admin']` / both / neither).
+
 ## Framework: @lenne.tech/nuxt-extensions
 
 This project consumes the framework in one of two modes:
@@ -231,6 +283,17 @@ All override targets use fixed versions (not ranges) to prevent silent major-ver
 The `ignoredOptionalDependencies` block in `pnpm-workspace.yaml` suppresses 30 platform-specific native binaries (`@img/sharp-*`, `@resvg/resvg-js-*`) that are pulled in by `@nuxtjs/seo` 5.x's OG image engine. Only the host-platform binary is needed at build time.
 
 Build-script approval for native deps (`sharp`, `esbuild`, `@parcel/watcher`, `simple-git-hooks`, `vue-demi`) is declared twice in `pnpm-workspace.yaml` for cross-version compatibility: `allowBuilds` (pnpm 11 key) and `onlyBuiltDependencies` (pnpm 10 key). Each pnpm version reads its own key and ignores the other.
+
+### `minimumReleaseAgeExclude` (pnpm 11 supply-chain policy)
+
+`pnpm-workspace.yaml` carries a `minimumReleaseAgeExclude` block listing exact `pkg@version` entries that are allowed to bypass the global minimum-release-age supply-chain guard (the guard rejects packages released within the last few days unless explicitly excluded). pnpm 11 auto-appends entries the first time a fresh dependency is installed, so the block grows whenever the project pulls in a same-day Better Auth / nuxt-extensions / nest-server release.
+
+**Maintenance rules:**
+
+- Each entry is intentional — it covers exactly one fresh version of one package. Do NOT loosen to a version range.
+- When bumping a covered dep, also remove the now-stale entry (e.g. after `1.7.1` ages out, drop the `1.7.1` line on the next bump).
+- Removing an entry without first removing the dependency or waiting for the age threshold will block `pnpm install` for everyone with the same lockfile until the age threshold is met.
+- Never disable the policy globally — it is the project's first line of defense against supply-chain attacks via freshly published malicious versions.
 
 ## Notable Version Changes (v2.5.x)
 

--- a/nuxt-base-template/CLAUDE.md
+++ b/nuxt-base-template/CLAUDE.md
@@ -57,6 +57,7 @@ lt dev status                  # show running PIDs + active URLs
 lt dev status --all            # list all registered projects
 lt dev doctor                  # diagnose Caddy / CA / DNS / port issues
 ```
+
 First run in a fresh project: just `lt dev init` then `lt dev up`. (`lt dev migrate` still works as an alias for `init`.)
 
 `lt dev up` exports the env vars the template respects:

--- a/nuxt-base-template/README.md
+++ b/nuxt-base-template/README.md
@@ -144,6 +144,28 @@ npm run generate-types
 - VueUse composition utilities
 - dayjs for date/time handling
 
+## AI Assistant
+
+Ready-to-use UI for the `@lenne.tech/nest-server` **AI module**, built on the
+`useLtAi*` composables from `@lenne.tech/nuxt-extensions` (NuxtUI + Valibot + toasts).
+
+| Route | Audience | Purpose |
+|-------|----------|---------|
+| `/app/ai` | any user | Streaming chat (`AiChat`) with confirmation flow + budget badge |
+| `/app/settings/ai` | any user | Pick the personal default connection + view token usage |
+| `/app/admin/ai/connections` | admin | Connection CRUD + capability auto-detection |
+| `/app/admin/ai/preferences` | admin | Tenant/user default connections (+ enforced) |
+| `/app/admin/ai/budgets` | admin | Per-user/tenant token & prompt limits |
+| `/app/admin/ai/interactions` | admin | Prompt audit log (requires `ai.audit`) |
+
+Components live in `app/components/Ai/` (`AiChat`, `AiMessage`, `AiConnectionPicker`,
+`AiUsageBadge`, `ModalAiConnection`). Admin routes are gated by `admin.global.ts`.
+
+**Requirements:** the backend must run the AI module (an `ai` config block) with at
+least one connection (admin-created or seeded via `AI_BASE_URL`). The streaming
+endpoint (`POST /ai/stream`) flows through the existing `/api` dev proxy. Configure the
+client base path in `nuxt.config.ts` (`ltExtensions.ai.basePath`, default `/ai`).
+
 ## Environment Variables
 
 Create a `.env` file with the following variables:

--- a/nuxt-base-template/README.md
+++ b/nuxt-base-template/README.md
@@ -149,20 +149,35 @@ npm run generate-types
 Ready-to-use UI for the `@lenne.tech/nest-server` **AI module**, built on the
 `useLtAi*` composables from `@lenne.tech/nuxt-extensions` (NuxtUI + Valibot + toasts).
 
-| Route                        | Audience | Purpose                                                         |
-| ---------------------------- | -------- | --------------------------------------------------------------- |
-| `/app/ai`                    | any user | Streaming chat (`AiChat`) with confirmation flow + budget badge |
-| `/app/settings/ai`           | any user | Pick the personal default connection + view token usage         |
-| `/app/admin/ai/connections`  | admin    | Connection CRUD + capability auto-detection                     |
-| `/app/admin/ai/preferences`  | admin    | Tenant/user default connections (+ enforced)                    |
-| `/app/admin/ai/budgets`      | admin    | Per-user/tenant token & prompt limits                           |
-| `/app/admin/ai/interactions` | admin    | Prompt audit log (requires `ai.audit`)                          |
+| Route                        | Audience | Purpose                                                                |
+| ---------------------------- | -------- | ---------------------------------------------------------------------- |
+| `/app/ai`                    | any user | Streaming chat (`AiChat`) with confirmation flow + token bar + popover |
+| `/app/settings/ai`           | any user | Pick the personal default connection + view token usage                |
+| `/app/settings/ai-prompts`   | any user | Manage own re-usable prompts ("Vorlagen"), share with tenant           |
+| `/app/admin/ai/connections`  | admin    | Connection CRUD + capability auto-detection                            |
+| `/app/admin/ai/preferences`  | admin    | Tenant/user default connections (+ enforced)                           |
+| `/app/admin/ai/budgets`      | admin    | Per-user/tenant token & prompt limits                                  |
+| `/app/admin/ai/interactions` | admin    | Prompt audit log (requires `ai.audit`)                                 |
+| `/app/admin/ai/slots`        | admin    | System-prompt slot editor: override / reset / soft-delete defaults     |
+| `/app/admin/ai/prompt-hints` | admin    | Learned hint review (approve / reject / activate)                      |
 
-Components live in `app/components/Ai/` (`AiChat`, `AiMessage`, `AiConnectionPicker`,
-`AiUsageBadge`, `ModalAiConnection`). Admin routes are gated by `admin.global.ts`.
+Components live in `app/components/Ai/`: `AiChat`, `AiMessage`, `AiConnectionPicker`,
+`AiContextWindow`, `AiPlaceholderHint`, `AiPromptPicker`, `AiTokenBar`, `AiUsageBadge`,
+`ModalAiConnection`. The header navigation gains four AI entries for authenticated users
+("KI-Assistent", "KI-Vorlagen", "KI-Einstellungen" + "Administration" for admins).
+Admin routes are gated by `app/middleware/admin.global.ts` (which delegates the
+role check to the auto-imported `isAdminUser()` helper in `app/utils/`).
 
-**Requirements:** the backend must run the AI module (an `ai` config block) with at
-least one connection (admin-created or seeded via `AI_BASE_URL`). The streaming
+**Opt-out:** set `ltExtensions.ai.enabled: false` in `nuxt.config.ts` to disable the
+client-side AI surface entirely (the layout nav entries and pages will still ship
+but the composables short-circuit). For a full opt-out, also delete `app/components/Ai/`,
+`app/pages/app/ai/`, `app/pages/app/admin/ai/`, `app/pages/app/settings/ai*.vue`
+and the corresponding header entries in `app/layouts/default.vue`.
+
+**Requirements:** the backend must run the `@lenne.tech/nest-server` AI module
+(11.26.0+) with at least one connection (admin-created or seeded via `AI_BASE_URL`).
+The expected REST routes are `/ai/{prompt,stream,connections,preferences,budget-limits,
+interactions,slots,prompts,prompt-hints,placeholders,usage,features}`. The streaming
 endpoint (`POST /ai/stream`) flows through the existing `/api` dev proxy. Configure the
 client base path in `nuxt.config.ts` (`ltExtensions.ai.basePath`, default `/ai`).
 
@@ -196,6 +211,7 @@ NUXT_PUBLIC_STORAGE_PREFIX=base-dev      # Local storage prefix
 app/
 ├── assets/css/      # Tailwind CSS styles
 ├── components/      # Vue components (auto-imported)
+│   ├── Ai/          # AI assistant UI (Chat, TokenBar, ContextWindow, ...)
 │   ├── Modal/       # Modal components
 │   ├── Transition/  # Transition animations
 │   └── Upload/      # File upload components
@@ -209,13 +225,20 @@ app/
 ├── lib/             # Auth client configuration
 ├── middleware/      # Route guards (auth, admin, guest)
 ├── pages/           # File-based routing
-│   ├── auth/        # Authentication pages
+│   ├── auth/        # Authentication pages (login, register hardening, 2FA, ...)
 │   └── app/         # Protected app pages
-├── utils/           # Utility functions
+│       ├── admin/   # Admin dashboard + AI admin (connections, budgets, slots, ...)
+│       ├── ai/      # AI chat
+│       └── settings/# User settings (security, ai, ai-prompts, ...)
+├── utils/           # Utility functions (auto-imported)
+│   └── is-admin-user.ts  # Dual-shape admin check (role vs roles[])
 └── app.config.ts    # NuxtUI configuration
 
 docs/                # Dev-only documentation layer
-tests/               # Playwright E2E tests
+tests/
+├── unit/            # Vitest unit tests (utils, composables, env)
+└── e2e/             # Playwright E2E tests
+    └── helpers/     # Shared test helpers (safe-form-submit, ...)
 ```
 
 ## Documentation

--- a/nuxt-base-template/README.md
+++ b/nuxt-base-template/README.md
@@ -149,14 +149,14 @@ npm run generate-types
 Ready-to-use UI for the `@lenne.tech/nest-server` **AI module**, built on the
 `useLtAi*` composables from `@lenne.tech/nuxt-extensions` (NuxtUI + Valibot + toasts).
 
-| Route | Audience | Purpose |
-|-------|----------|---------|
-| `/app/ai` | any user | Streaming chat (`AiChat`) with confirmation flow + budget badge |
-| `/app/settings/ai` | any user | Pick the personal default connection + view token usage |
-| `/app/admin/ai/connections` | admin | Connection CRUD + capability auto-detection |
-| `/app/admin/ai/preferences` | admin | Tenant/user default connections (+ enforced) |
-| `/app/admin/ai/budgets` | admin | Per-user/tenant token & prompt limits |
-| `/app/admin/ai/interactions` | admin | Prompt audit log (requires `ai.audit`) |
+| Route                        | Audience | Purpose                                                         |
+| ---------------------------- | -------- | --------------------------------------------------------------- |
+| `/app/ai`                    | any user | Streaming chat (`AiChat`) with confirmation flow + budget badge |
+| `/app/settings/ai`           | any user | Pick the personal default connection + view token usage         |
+| `/app/admin/ai/connections`  | admin    | Connection CRUD + capability auto-detection                     |
+| `/app/admin/ai/preferences`  | admin    | Tenant/user default connections (+ enforced)                    |
+| `/app/admin/ai/budgets`      | admin    | Per-user/tenant token & prompt limits                           |
+| `/app/admin/ai/interactions` | admin    | Prompt audit log (requires `ai.audit`)                          |
 
 Components live in `app/components/Ai/` (`AiChat`, `AiMessage`, `AiConnectionPicker`,
 `AiUsageBadge`, `ModalAiConnection`). Admin routes are gated by `admin.global.ts`.

--- a/nuxt-base-template/app/components/Ai/AiChat.vue
+++ b/nuxt-base-template/app/components/Ai/AiChat.vue
@@ -40,12 +40,12 @@ async function onSubmit(): Promise<void> {
   await send(text);
 }
 
-function onSnippetSelect(snippet: { content: string }): void {
-  // Append snippet text to the current draft (with a separator if needed) so the
+function onPromptSelect(prompt: { content: string }): void {
+  // Append prompt text to the current draft (with a separator if needed) so the
   // user can still tweak it before sending. Focuses the existing draft instead
-  // of replacing it — picking a snippet is additive.
+  // of replacing it — picking a prompt is additive.
   const sep = input.value && !/\s$/.test(input.value) ? '\n' : '';
-  input.value = `${input.value}${sep}${snippet.content}`;
+  input.value = `${input.value}${sep}${prompt.content}`;
 }
 </script>
 
@@ -78,7 +78,7 @@ function onSnippetSelect(snippet: { content: string }): void {
 
     <!-- Input -->
     <form class="flex items-end gap-2" @submit.prevent="onSubmit">
-      <AiSnippetPicker @select="onSnippetSelect" />
+      <AiPromptPicker @select="onPromptSelect" />
       <UTextarea v-model="input" :rows="1" autoresize class="flex-1" placeholder="Nachricht eingeben …" :disabled="streaming" @keydown.enter.exact.prevent="onSubmit" />
       <UButton v-if="streaming" color="neutral" variant="outline" icon="i-lucide-square" aria-label="Stop" @click="stop" />
       <UButton v-else type="submit" color="primary" icon="i-lucide-send" :disabled="!input.trim()" aria-label="Senden" />

--- a/nuxt-base-template/app/components/Ai/AiChat.vue
+++ b/nuxt-base-template/app/components/Ai/AiChat.vue
@@ -1,0 +1,84 @@
+<script setup lang="ts">
+// ============================================================================
+// AI chat container — wires useLtAiChat (streaming, conversation, budget,
+// confirmation) to a message list + input. Self-contained and reusable.
+// ============================================================================
+const props = withDefaults(
+  defineProps<{
+    /** Continue an existing conversation. */
+    conversationId?: string;
+    /** Execution mode for every turn. */
+    mode?: 'auto' | 'plan';
+    /** Show the user connection picker (default true). */
+    showConnectionPicker?: boolean;
+  }>(),
+  { showConnectionPicker: true },
+);
+
+const { budget, clear, confirm, error, messages, send, stop, streaming } = useLtAiChat({
+  conversationId: props.conversationId,
+  // Enrich each prompt with lightweight client context (untrusted, capped server-side).
+  metadata: () => ({ url: import.meta.client ? window.location.href : undefined }),
+  mode: props.mode,
+});
+
+const input = ref('');
+const listEl = ref<HTMLElement | null>(null);
+
+// Auto-scroll to the latest message while streaming.
+watch(
+  () => messages.value.map((m) => m.content).join('|'),
+  async () => {
+    await nextTick();
+    listEl.value?.scrollTo({ behavior: 'smooth', top: listEl.value.scrollHeight });
+  },
+);
+
+async function onSubmit(): Promise<void> {
+  const text = input.value;
+  input.value = '';
+  await send(text);
+}
+</script>
+
+<template>
+  <div class="flex h-full flex-col gap-3">
+    <!-- Toolbar -->
+    <div class="flex flex-wrap items-center justify-between gap-2">
+      <AiConnectionPicker v-if="showConnectionPicker" />
+      <div class="flex items-center gap-2">
+        <AiUsageBadge :budget="budget" />
+        <UButton v-if="messages.length" size="sm" color="neutral" variant="ghost" icon="i-lucide-eraser" @click="clear"> Leeren </UButton>
+      </div>
+    </div>
+
+    <!-- Messages -->
+    <div ref="listEl" class="flex-1 space-y-3 overflow-y-auto rounded-lg border border-default p-4">
+      <div v-if="!messages.length" class="flex h-full min-h-40 items-center justify-center text-center text-muted">
+        <div>
+          <UIcon name="i-lucide-sparkles" class="mx-auto mb-2 size-8" />
+          <p>Stelle dem KI-Assistenten eine Frage.</p>
+        </div>
+      </div>
+      <AiMessage v-for="(message, i) in messages" :key="i" :message="message" @confirm="confirm" />
+    </div>
+
+    <!-- Error -->
+    <UAlert v-if="error" color="error" variant="subtle" icon="i-lucide-alert-circle" :description="error" />
+
+    <!-- Input -->
+    <form class="flex items-end gap-2" @submit.prevent="onSubmit">
+      <UTextarea
+        v-model="input"
+        :rows="1"
+        autoresize
+        class="flex-1"
+        placeholder="Nachricht eingeben …"
+        :disabled="streaming"
+        @keydown.enter.exact.prevent="onSubmit"
+      />
+      <UButton v-if="streaming" color="neutral" variant="outline" icon="i-lucide-square" aria-label="Stop" @click="stop" />
+      <UButton v-else type="submit" color="primary" icon="i-lucide-send" :disabled="!input.trim()" aria-label="Senden" />
+    </form>
+  </div>
+</template>

--- a/nuxt-base-template/app/components/Ai/AiChat.vue
+++ b/nuxt-base-template/app/components/Ai/AiChat.vue
@@ -15,7 +15,7 @@ const props = withDefaults(
   { showConnectionPicker: true },
 );
 
-const { budget, clear, confirm, error, messages, send, stop, streaming } = useLtAiChat({
+const { budget, clear, confirm, contextWindow, error, messages, send, stop, streaming } = useLtAiChat({
   conversationId: props.conversationId,
   // Enrich each prompt with lightweight client context (untrusted, capped server-side).
   metadata: () => ({ url: import.meta.client ? window.location.href : undefined }),
@@ -46,7 +46,9 @@ async function onSubmit(): Promise<void> {
     <!-- Toolbar -->
     <div class="flex flex-wrap items-center justify-between gap-2">
       <AiConnectionPicker v-if="showConnectionPicker" />
-      <div class="flex items-center gap-2">
+      <div class="flex items-center gap-3">
+        <AiTokenBar :budget="budget" />
+        <AiContextWindow :context-window="contextWindow" />
         <AiUsageBadge :budget="budget" />
         <UButton v-if="messages.length" size="sm" color="neutral" variant="ghost" icon="i-lucide-eraser" @click="clear"> Leeren </UButton>
       </div>

--- a/nuxt-base-template/app/components/Ai/AiChat.vue
+++ b/nuxt-base-template/app/components/Ai/AiChat.vue
@@ -17,6 +17,8 @@ const props = withDefaults(
 
 const { budget, clear, confirm, contextWindow, error, messages, send, stop, streaming } = useLtAiChat({
   conversationId: props.conversationId,
+  // Cap history so long-running chat tabs don't grow `messages` unbounded.
+  maxMessages: 100,
   // Enrich each prompt with lightweight client context (untrusted, capped server-side).
   metadata: () => ({ url: import.meta.client ? window.location.href : undefined }),
   mode: props.mode,
@@ -25,9 +27,11 @@ const { budget, clear, confirm, contextWindow, error, messages, send, stop, stre
 const input = ref('');
 const listEl = ref<HTMLElement | null>(null);
 
-// Auto-scroll to the latest message while streaming.
+// Auto-scroll to the latest message while streaming. Watch only length + the
+// last message's content so the source stays O(1) per SSE token — the previous
+// `messages.map(...).join('|')` allocated an O(n·m) string on every token.
 watch(
-  () => messages.value.map((m) => m.content).join('|'),
+  () => [messages.value.length, messages.value.at(-1)?.content],
   async () => {
     await nextTick();
     listEl.value?.scrollTo({ behavior: 'smooth', top: listEl.value.scrollHeight });

--- a/nuxt-base-template/app/components/Ai/AiChat.vue
+++ b/nuxt-base-template/app/components/Ai/AiChat.vue
@@ -68,15 +68,7 @@ async function onSubmit(): Promise<void> {
 
     <!-- Input -->
     <form class="flex items-end gap-2" @submit.prevent="onSubmit">
-      <UTextarea
-        v-model="input"
-        :rows="1"
-        autoresize
-        class="flex-1"
-        placeholder="Nachricht eingeben …"
-        :disabled="streaming"
-        @keydown.enter.exact.prevent="onSubmit"
-      />
+      <UTextarea v-model="input" :rows="1" autoresize class="flex-1" placeholder="Nachricht eingeben …" :disabled="streaming" @keydown.enter.exact.prevent="onSubmit" />
       <UButton v-if="streaming" color="neutral" variant="outline" icon="i-lucide-square" aria-label="Stop" @click="stop" />
       <UButton v-else type="submit" color="primary" icon="i-lucide-send" :disabled="!input.trim()" aria-label="Senden" />
     </form>

--- a/nuxt-base-template/app/components/Ai/AiChat.vue
+++ b/nuxt-base-template/app/components/Ai/AiChat.vue
@@ -39,6 +39,14 @@ async function onSubmit(): Promise<void> {
   input.value = '';
   await send(text);
 }
+
+function onSnippetSelect(snippet: { content: string }): void {
+  // Append snippet text to the current draft (with a separator if needed) so the
+  // user can still tweak it before sending. Focuses the existing draft instead
+  // of replacing it — picking a snippet is additive.
+  const sep = input.value && !/\s$/.test(input.value) ? '\n' : '';
+  input.value = `${input.value}${sep}${snippet.content}`;
+}
 </script>
 
 <template>
@@ -70,6 +78,7 @@ async function onSubmit(): Promise<void> {
 
     <!-- Input -->
     <form class="flex items-end gap-2" @submit.prevent="onSubmit">
+      <AiSnippetPicker @select="onSnippetSelect" />
       <UTextarea v-model="input" :rows="1" autoresize class="flex-1" placeholder="Nachricht eingeben …" :disabled="streaming" @keydown.enter.exact.prevent="onSubmit" />
       <UButton v-if="streaming" color="neutral" variant="outline" icon="i-lucide-square" aria-label="Stop" @click="stop" />
       <UButton v-else type="submit" color="primary" icon="i-lucide-send" :disabled="!input.trim()" aria-label="Senden" />

--- a/nuxt-base-template/app/components/Ai/AiChat.vue
+++ b/nuxt-base-template/app/components/Ai/AiChat.vue
@@ -58,8 +58,8 @@ function onPromptSelect(prompt: { content: string }): void {
         <AiTokenBar :budget="budget" />
         <AiContextWindow :context-window="contextWindow" />
         <AiUsageBadge :budget="budget" />
-        <UButton v-if="messages.length" size="sm" color="neutral" variant="ghost" icon="i-lucide-eraser" @click="clear"> Leeren </UButton>
       </div>
+      <UButton v-if="messages.length" size="sm" color="neutral" variant="ghost" icon="i-lucide-eraser" title="Konversation leeren" @click="clear"> Konversation leeren </UButton>
     </div>
 
     <!-- Messages -->

--- a/nuxt-base-template/app/components/Ai/AiConnectionPicker.vue
+++ b/nuxt-base-template/app/components/Ai/AiConnectionPicker.vue
@@ -37,15 +37,7 @@ async function choose(id: string): Promise<void> {
 <template>
   <div v-if="connections.length > 1" class="flex items-center gap-2">
     <UIcon name="i-lucide-plug" class="size-4 text-muted" />
-    <USelectMenu
-      v-model="selectedId"
-      :items="items"
-      value-key="value"
-      :disabled="locked"
-      placeholder="KI-Verbindung wählen"
-      size="sm"
-      class="min-w-48"
-    />
+    <USelectMenu v-model="selectedId" :items="items" value-key="value" :disabled="locked" placeholder="KI-Verbindung wählen" size="sm" class="min-w-48" />
     <UTooltip v-if="locked" text="Die Verbindung ist vorgegeben und kann nicht geändert werden.">
       <UIcon name="i-lucide-lock" class="size-4 text-muted" />
     </UTooltip>

--- a/nuxt-base-template/app/components/Ai/AiConnectionPicker.vue
+++ b/nuxt-base-template/app/components/Ai/AiConnectionPicker.vue
@@ -1,0 +1,53 @@
+<script setup lang="ts">
+// ============================================================================
+// AI connection picker — user self-service selection of the LLM connection.
+// Hidden when only one connection is available or the choice is locked by a
+// mandatory (admin/tenant-enforced) layer.
+// ============================================================================
+const toast = useToast();
+const { connections, load, locked, select, selected } = useLtAiConnections();
+
+const items = computed(() =>
+  connections.value.map((c) => ({
+    label: c.name || c.id,
+    value: c.id,
+  })),
+);
+
+const selectedId = computed({
+  get: () => selected.value?.id,
+  set: (id?: string) => {
+    if (id) {
+      void choose(id);
+    }
+  },
+});
+
+onMounted(load);
+
+async function choose(id: string): Promise<void> {
+  try {
+    await select(id);
+  } catch (err) {
+    toast.add({ color: 'error', description: (err as Error).message, title: 'Fehler' });
+  }
+}
+</script>
+
+<template>
+  <div v-if="connections.length > 1" class="flex items-center gap-2">
+    <UIcon name="i-lucide-plug" class="size-4 text-muted" />
+    <USelectMenu
+      v-model="selectedId"
+      :items="items"
+      value-key="value"
+      :disabled="locked"
+      placeholder="KI-Verbindung wählen"
+      size="sm"
+      class="min-w-48"
+    />
+    <UTooltip v-if="locked" text="Die Verbindung ist vorgegeben und kann nicht geändert werden.">
+      <UIcon name="i-lucide-lock" class="size-4 text-muted" />
+    </UTooltip>
+  </div>
+</template>

--- a/nuxt-base-template/app/components/Ai/AiContextWindow.vue
+++ b/nuxt-base-template/app/components/Ai/AiContextWindow.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 // ============================================================================
-// Context-Window-Indikator — schließender Kreis im Claude-Code-Stil. Erscheint
-// erst ab 60% Nutzung; bei 100% ist der Kreis voll geschlossen. Tooltip auf
-// Hover zeigt den exakten Prozentsatz und die Token-Werte.
+// Context window indicator — a closing ring in the Claude-Code style. Only
+// shown once usage hits 60 %; at 100 % the ring is fully closed. Hover
+// surfaces the exact percentage + token values via tooltip.
 // ============================================================================
 const props = defineProps<{
   contextWindow?: { total: number; used: number } | null;

--- a/nuxt-base-template/app/components/Ai/AiContextWindow.vue
+++ b/nuxt-base-template/app/components/Ai/AiContextWindow.vue
@@ -1,0 +1,58 @@
+<script setup lang="ts">
+// ============================================================================
+// Context-Window-Indikator — schließender Kreis im Claude-Code-Stil. Erscheint
+// erst ab 60% Nutzung; bei 100% ist der Kreis voll geschlossen. Tooltip auf
+// Hover zeigt den exakten Prozentsatz und die Token-Werte.
+// ============================================================================
+const props = defineProps<{
+  contextWindow?: { total: number; used: number } | null;
+}>();
+
+const percent = computed(() => {
+  const cw = props.contextWindow;
+  if (!cw || cw.total <= 0) return 0;
+  return Math.min(100, (cw.used / cw.total) * 100);
+});
+
+const visible = computed(() => !!props.contextWindow && percent.value >= 60);
+
+// SVG arc: full = 100%, empty = 0%. Stroke-dashoffset goes from circumference (empty) to 0 (full).
+const radius = 8;
+const circumference = computed(() => 2 * Math.PI * radius);
+const dashOffset = computed(() => circumference.value * (1 - percent.value / 100));
+
+const ringClass = computed(() => {
+  if (percent.value >= 90) return 'text-red-500';
+  if (percent.value >= 75) return 'text-amber-500';
+  return 'text-primary';
+});
+
+const tooltipText = computed(() => {
+  const cw = props.contextWindow!;
+  return [`Kontextfenster: ${percent.value.toFixed(1)}% genutzt`, `Verbraucht: ${cw.used.toLocaleString('de-DE')} / ${cw.total.toLocaleString('de-DE')} Tokens`].join('\n');
+});
+</script>
+
+<template>
+  <UTooltip v-if="visible" :text="tooltipText" :delay-duration="100">
+    <div class="inline-flex size-6 items-center justify-center" role="img" :aria-label="`Kontextfenster ${percent.toFixed(0)}% genutzt`">
+      <svg viewBox="0 0 20 20" class="size-5 -rotate-90" :class="ringClass">
+        <!-- background ring -->
+        <circle cx="10" cy="10" :r="radius" fill="none" stroke="currentColor" stroke-opacity="0.15" stroke-width="2.5" />
+        <!-- progress arc -->
+        <circle
+          cx="10"
+          cy="10"
+          :r="radius"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2.5"
+          stroke-linecap="round"
+          :stroke-dasharray="circumference"
+          :stroke-dashoffset="dashOffset"
+          class="transition-[stroke-dashoffset] duration-300"
+        />
+      </svg>
+    </div>
+  </UTooltip>
+</template>

--- a/nuxt-base-template/app/components/Ai/AiMessage.vue
+++ b/nuxt-base-template/app/components/Ai/AiMessage.vue
@@ -1,0 +1,63 @@
+<script setup lang="ts">
+// ============================================================================
+// A single chat message (user or assistant). Renders the streamed/final text,
+// executed tool actions, and the confirmation prompt for mutating/destructive
+// actions awaiting approval.
+// ============================================================================
+import type { LtAiMessage } from '@lenne.tech/nuxt-extensions';
+
+defineProps<{
+  message: LtAiMessage;
+}>();
+
+const emit = defineEmits<{
+  confirm: [];
+}>();
+</script>
+
+<template>
+  <div class="flex" :class="message.role === 'user' ? 'justify-end' : 'justify-start'">
+    <div
+      class="max-w-[85%] rounded-lg px-4 py-2 text-sm"
+      :class="message.role === 'user' ? 'bg-primary text-inverted' : 'bg-elevated text-default'"
+    >
+      <!-- Text (streamed or final) -->
+      <p class="whitespace-pre-wrap break-words">{{ message.content }}</p>
+      <span v-if="message.pending" class="inline-block animate-pulse text-muted">▍</span>
+
+      <!-- Executed tool actions -->
+      <div v-if="message.actions?.length" class="mt-2 flex flex-wrap gap-1">
+        <UBadge
+          v-for="(action, i) in message.actions"
+          :key="i"
+          size="sm"
+          :color="action.success === false ? 'error' : 'success'"
+          variant="subtle"
+          :icon="action.success === false ? 'i-lucide-x' : 'i-lucide-check'"
+        >
+          {{ action.name }}
+        </UBadge>
+      </div>
+
+      <!-- Denied (plan mode, missing permissions) -->
+      <UAlert
+        v-if="message.denied"
+        class="mt-2"
+        color="error"
+        variant="subtle"
+        icon="i-lucide-shield-x"
+        :description="'Es wurde nichts ausgeführt.'"
+      />
+
+      <!-- Confirmation gate -->
+      <div v-if="message.requiresConfirmation" class="mt-3 space-y-2">
+        <div v-if="message.pendingActions?.length" class="flex flex-wrap gap-1">
+          <UBadge v-for="(action, i) in message.pendingActions" :key="i" size="sm" color="warning" variant="subtle" icon="i-lucide-alert-triangle">
+            {{ action.name }}
+          </UBadge>
+        </div>
+        <UButton size="sm" color="warning" icon="i-lucide-check" @click="emit('confirm')"> Ausführung bestätigen </UButton>
+      </div>
+    </div>
+  </div>
+</template>

--- a/nuxt-base-template/app/components/Ai/AiMessage.vue
+++ b/nuxt-base-template/app/components/Ai/AiMessage.vue
@@ -17,10 +17,7 @@ const emit = defineEmits<{
 
 <template>
   <div class="flex" :class="message.role === 'user' ? 'justify-end' : 'justify-start'">
-    <div
-      class="max-w-[85%] rounded-lg px-4 py-2 text-sm"
-      :class="message.role === 'user' ? 'bg-primary text-inverted' : 'bg-elevated text-default'"
-    >
+    <div class="max-w-[85%] rounded-lg px-4 py-2 text-sm" :class="message.role === 'user' ? 'bg-primary text-inverted' : 'bg-elevated text-default'">
       <!-- Text (streamed or final) -->
       <p class="whitespace-pre-wrap break-words">{{ message.content }}</p>
       <span v-if="message.pending" class="inline-block animate-pulse text-muted">▍</span>
@@ -40,14 +37,7 @@ const emit = defineEmits<{
       </div>
 
       <!-- Denied (plan mode, missing permissions) -->
-      <UAlert
-        v-if="message.denied"
-        class="mt-2"
-        color="error"
-        variant="subtle"
-        icon="i-lucide-shield-x"
-        :description="'Es wurde nichts ausgeführt.'"
-      />
+      <UAlert v-if="message.denied" class="mt-2" color="error" variant="subtle" icon="i-lucide-shield-x" :description="'Es wurde nichts ausgeführt.'" />
 
       <!-- Confirmation gate -->
       <div v-if="message.requiresConfirmation" class="mt-3 space-y-2">

--- a/nuxt-base-template/app/components/Ai/AiPlaceholderHint.vue
+++ b/nuxt-base-template/app/components/Ai/AiPlaceholderHint.vue
@@ -1,0 +1,51 @@
+<script setup lang="ts">
+// ============================================================================
+// Placeholder helper sidebar — lists every `{{placeholder}}` the backend
+// supports (registry-driven, so project-specific additions are picked up
+// automatically). Click copies the token to the clipboard.
+// ============================================================================
+const toast = useToast();
+const { error, load, loading, placeholders } = useLtAiPlaceholders();
+
+onMounted(load);
+
+function token(name: string): string {
+  return '{' + '{' + name + '}' + '}';
+}
+
+async function copy(name: string): Promise<void> {
+  const t = token(name);
+  try {
+    await navigator.clipboard.writeText(t);
+    toast.add({ color: 'success', description: `${t} kopiert`, title: 'Platzhalter' });
+  } catch {
+    toast.add({ color: 'error', description: 'Zwischenablage nicht verfügbar', title: 'Fehler' });
+  }
+}
+</script>
+
+<template>
+  <UCard>
+    <template #header>
+      <div class="flex items-center gap-2">
+        <UIcon name="i-lucide-braces" class="size-4" />
+        <h3 class="font-semibold">Verfügbare Platzhalter</h3>
+      </div>
+    </template>
+    <p class="mb-3 text-xs text-muted">Tokens wie <code>&#123;&#123;name&#125;&#125;</code> werden zur Laufzeit ersetzt. Klick auf einen Eintrag kopiert ihn.</p>
+    <div v-if="loading" class="py-4 text-center text-muted">
+      <UIcon name="i-lucide-loader-circle" class="size-5 animate-spin" />
+    </div>
+    <UAlert v-else-if="error" color="error" variant="subtle" icon="i-lucide-alert-circle" :description="error" />
+    <div v-else-if="!placeholders.length" class="py-2 text-xs text-muted">Keine Platzhalter verfügbar.</div>
+    <ul v-else class="space-y-2">
+      <li v-for="p in placeholders" :key="p.name" class="cursor-pointer rounded p-2 hover:bg-elevated" :title="p.example || ''" @click="copy(p.name)">
+        <div class="flex items-center gap-2">
+          <UBadge size="xs" variant="subtle">{{ token(p.name) }}</UBadge>
+          <UIcon name="i-lucide-copy" class="size-3 text-muted" />
+        </div>
+        <p class="mt-1 text-xs text-muted">{{ p.description }}</p>
+      </li>
+    </ul>
+  </UCard>
+</template>

--- a/nuxt-base-template/app/components/Ai/AiPromptPicker.vue
+++ b/nuxt-base-template/app/components/Ai/AiPromptPicker.vue
@@ -1,14 +1,14 @@
 <script setup lang="ts">
 // ============================================================================
-// Snippet ("Vorlage") picker — drop-down next to the chat input. Lists every
-// snippet the current user is allowed to see (own + tenant + global) and emits
-// the selected snippet's content so the parent can insert it into the input.
+// Prompt ("Vorlage") picker — drop-down next to the chat input. Lists every
+// prompt the current user is allowed to see (own private + tenant public)
+// and emits the selected prompt so the parent can insert its content.
 // ============================================================================
-import type { LtAiPromptSnippet } from '@lenne.tech/nuxt-extensions';
+import type { LtAiPrompt } from '@lenne.tech/nuxt-extensions';
 
-const emit = defineEmits<{ select: [snippet: LtAiPromptSnippet] }>();
+const emit = defineEmits<{ select: [prompt: LtAiPrompt] }>();
 
-const { error, load, loading, snippets } = useLtAiSnippets();
+const { error, load, loading, prompts } = useLtAiPrompts();
 
 onMounted(() => {
   void load();
@@ -16,25 +16,23 @@ onMounted(() => {
 
 // Group by scope so the menu is easy to scan.
 const grouped = computed(() => ({
-  user: snippets.value.filter((s) => s.scope === 'user'),
-  tenant: snippets.value.filter((s) => s.scope === 'tenant'),
-  global: snippets.value.filter((s) => s.scope === 'global'),
+  user: prompts.value.filter((s) => s.scope === 'user'),
+  tenant: prompts.value.filter((s) => s.scope === 'tenant'),
 }));
 
-function iconFor(s: LtAiPromptSnippet): string | undefined {
+function iconFor(s: LtAiPrompt): string | undefined {
   return s.icon?.startsWith('i-') ? s.icon : undefined;
 }
 
-function pick(s: LtAiPromptSnippet): void {
+function pick(s: LtAiPrompt): void {
   emit('select', s);
 }
 
 const menuItems = computed(() => {
   const sections: Array<Array<{ label: string; icon?: string; onSelect: () => void; disabled?: boolean }>> = [];
-  const order: Array<['user' | 'tenant' | 'global', string]> = [
-    ['user', 'Eigene'],
+  const order: Array<['user' | 'tenant', string]> = [
+    ['user', 'Eigene (privat)'],
     ['tenant', 'Geteilt (Tenant)'],
-    ['global', 'Global'],
   ];
   for (const [key, label] of order) {
     const items = grouped.value[key];
@@ -64,7 +62,7 @@ const menuItems = computed(() => {
       :icon="loading ? 'i-lucide-loader-2' : 'i-lucide-clipboard-list'"
       :class="{ 'animate-spin': loading }"
       aria-label="Vorlagen einfügen"
-      data-test="ai-snippet-picker"
+      data-test="ai-prompt-picker"
     >
       Vorlagen
     </UButton>

--- a/nuxt-base-template/app/components/Ai/AiSnippetPicker.vue
+++ b/nuxt-base-template/app/components/Ai/AiSnippetPicker.vue
@@ -1,0 +1,75 @@
+<script setup lang="ts">
+// ============================================================================
+// Snippet ("Vorlage") picker — drop-down next to the chat input. Lists every
+// snippet the current user is allowed to see (own + tenant + global) and emits
+// the selected snippet's content so the parent can insert it into the input.
+// ============================================================================
+import type { LtAiPromptSnippet } from '@lenne.tech/nuxt-extensions';
+
+const emit = defineEmits<{ select: [snippet: LtAiPromptSnippet] }>();
+
+const { error, load, loading, snippets } = useLtAiSnippets();
+
+onMounted(() => {
+  void load();
+});
+
+// Group by scope so the menu is easy to scan.
+const grouped = computed(() => ({
+  user: snippets.value.filter((s) => s.scope === 'user'),
+  tenant: snippets.value.filter((s) => s.scope === 'tenant'),
+  global: snippets.value.filter((s) => s.scope === 'global'),
+}));
+
+function iconFor(s: LtAiPromptSnippet): string | undefined {
+  return s.icon?.startsWith('i-') ? s.icon : undefined;
+}
+
+function pick(s: LtAiPromptSnippet): void {
+  emit('select', s);
+}
+
+const menuItems = computed(() => {
+  const sections: Array<Array<{ label: string; icon?: string; onSelect: () => void; disabled?: boolean }>> = [];
+  const order: Array<['user' | 'tenant' | 'global', string]> = [
+    ['user', 'Eigene'],
+    ['tenant', 'Geteilt (Tenant)'],
+    ['global', 'Global'],
+  ];
+  for (const [key, label] of order) {
+    const items = grouped.value[key];
+    if (!items.length) continue;
+    sections.push([
+      { label, icon: undefined, onSelect: () => {}, disabled: true },
+      ...items.map((s) => ({
+        label: s.name,
+        icon: iconFor(s),
+        onSelect: () => pick(s),
+      })),
+    ]);
+  }
+  if (!sections.length) {
+    sections.push([{ label: 'Noch keine Vorlagen', onSelect: () => {}, disabled: true }]);
+  }
+  return sections;
+});
+</script>
+
+<template>
+  <UDropdownMenu :items="menuItems" :ui="{ content: 'min-w-64' }">
+    <UButton
+      size="sm"
+      color="neutral"
+      variant="ghost"
+      :icon="loading ? 'i-lucide-loader-2' : 'i-lucide-clipboard-list'"
+      :class="{ 'animate-spin': loading }"
+      aria-label="Vorlagen einfügen"
+      data-test="ai-snippet-picker"
+    >
+      Vorlagen
+    </UButton>
+    <template v-if="error" #content-bottom>
+      <p class="px-3 py-1 text-xs text-error">{{ error }}</p>
+    </template>
+  </UDropdownMenu>
+</template>

--- a/nuxt-base-template/app/components/Ai/AiTokenBar.vue
+++ b/nuxt-base-template/app/components/Ai/AiTokenBar.vue
@@ -1,0 +1,68 @@
+<script setup lang="ts">
+// ============================================================================
+// Token-Usage-Balken — visualisiert verbrauchte (links), verbleibende (rechts)
+// und Gesamt-Tokens (volle Breite) für das aktuelle Limit.
+//
+// Limit-Resolution (Backend liefert das bereits aufgelöst): User-Limit →
+// Tenant-Limit → LLM-Context-Window. Wenn `maxTokens` nicht gesetzt ist, gibt es
+// kein effektives Limit → die Komponente rendert nichts.
+//
+// Tooltip auf Hover zeigt die exakten Zahlen, das Scope-Label und den Reset-Zeitpunkt.
+// ============================================================================
+import type { LtAiBudgetSummary } from '@lenne.tech/nuxt-extensions';
+
+const props = defineProps<{
+  budget?: LtAiBudgetSummary | null;
+}>();
+
+const max = computed(() => (typeof props.budget?.maxTokens === 'number' ? props.budget.maxTokens : 0));
+const used = computed(() => (typeof props.budget?.usedTokens === 'number' ? props.budget.usedTokens : 0));
+const remaining = computed(() => (typeof props.budget?.remainingTokens === 'number' ? props.budget.remainingTokens : Math.max(0, max.value - used.value)));
+const usedPercent = computed(() => (max.value > 0 ? Math.min(100, (used.value / max.value) * 100) : 0));
+
+const scopeLabel = computed(() => {
+  switch (props.budget?.scope) {
+    case 'llm':
+      return 'LLM-Kontextfenster';
+    case 'tenant':
+      return 'Tenant-Limit';
+    case 'user':
+      return 'Nutzer-Limit';
+    default:
+      return 'Limit';
+  }
+});
+
+const resetAt = computed(() => (props.budget?.resetAt ? new Date(props.budget.resetAt).toLocaleString('de-DE') : ''));
+
+// Color logic: green up to 50%, amber 50–85%, red above
+const barClass = computed(() => {
+  if (usedPercent.value >= 85) return 'bg-red-500';
+  if (usedPercent.value >= 50) return 'bg-amber-500';
+  return 'bg-emerald-500';
+});
+
+const visible = computed(() => max.value > 0);
+
+const tooltipText = computed(() => {
+  const lines = [
+    `${scopeLabel.value}: ${max.value.toLocaleString('de-DE')} Tokens`,
+    `Verbraucht: ${used.value.toLocaleString('de-DE')} (${usedPercent.value.toFixed(1)}%)`,
+    `Übrig: ${remaining.value.toLocaleString('de-DE')}`,
+  ];
+  if (resetAt.value) lines.push(`Reset: ${resetAt.value}`);
+  return lines.join('\n');
+});
+</script>
+
+<template>
+  <UTooltip v-if="visible" :text="tooltipText" :delay-duration="100">
+    <div class="flex items-center gap-2" :aria-label="tooltipText">
+      <UIcon name="i-lucide-coins" class="size-4 shrink-0 text-muted" />
+      <div class="relative h-2 w-32 overflow-hidden rounded-full bg-elevated">
+        <div class="h-full rounded-full transition-all" :class="barClass" :style="{ width: usedPercent + '%' }" />
+      </div>
+      <span class="text-xs text-muted tabular-nums"> {{ used.toLocaleString('de-DE') }} / {{ max.toLocaleString('de-DE') }} </span>
+    </div>
+  </UTooltip>
+</template>

--- a/nuxt-base-template/app/components/Ai/AiTokenBar.vue
+++ b/nuxt-base-template/app/components/Ai/AiTokenBar.vue
@@ -1,16 +1,18 @@
 <script setup lang="ts">
 // ============================================================================
-// Token-Usage-Balken — visualisiert verbrauchte (links), verbleibende (rechts)
-// und Gesamt-Tokens (volle Breite) für das aktuelle Limit.
+// Token-Usage-Balken — visualisiert den KUMULATIVEN Tokenverbrauch des Nutzers
+// im aktuellen Zeitraum gegen das aktuelle Limit.
 //
-// Limit-Resolution (Backend liefert das bereits aufgelöst): User-Limit →
-// Tenant-Limit → LLM-Context-Window. Wenn `maxTokens` nicht gesetzt ist, gibt es
-// kein effektives Limit → die Komponente rendert nichts.
+// Limit-Resolution (Backend liefert das bereits aufgelöst):
+//   1. Nutzer-Limit (admin-konfiguriert; harte Sperre via 429)
+//   2. Tenant-Limit (admin-konfiguriert; harte Sperre via 429)
+//   3. Anbieter-Quota (`connection.defaultUserMaxTokens`, admin-gepflegt;
+//      weiches Default für scope='llm')
+//   4. LLM-Kontextfenster (allerletzter Fallback; scope='llm')
 //
-// Wenn `scope === 'llm'` (kein echtes Budget, nur Context-Window), zeigt der
-// Balken die Tokens der LETZTEN Anfrage gegen das Context-Window — kumulativer
-// `usedTokens` ist hier per Definition immer 0, der relevante Wert ist
-// `promptTokens`. Bei user/tenant zählt der kumulierte Periodenverbrauch.
+// `usedTokens` ist IMMER der kumulierte Periodenverbrauch des Nutzers — auch
+// bei scope='llm'. Wenn `maxTokens` nicht gesetzt ist (kein Limit irgendeiner
+// Art), rendert die Komponente nichts.
 //
 // Tooltip auf Hover zeigt die exakten Zahlen, das Scope-Label und den Reset-Zeitpunkt.
 // ============================================================================
@@ -22,19 +24,10 @@ const props = defineProps<{
 
 const isLlmScope = computed(() => props.budget?.scope === 'llm');
 const max = computed(() => (typeof props.budget?.maxTokens === 'number' ? props.budget.maxTokens : 0));
-
-// For LLM-context-window scope, the bar shows the LAST request against the window
-// (cumulative `usedTokens` is always 0 in that case). For user/tenant budgets it's
-// the running per-period total.
-const used = computed(() => {
-  if (isLlmScope.value) {
-    return typeof props.budget?.promptTokens === 'number' ? props.budget.promptTokens : 0;
-  }
-  return typeof props.budget?.usedTokens === 'number' ? props.budget.usedTokens : 0;
-});
+const used = computed(() => (typeof props.budget?.usedTokens === 'number' ? props.budget.usedTokens : 0));
 
 const remaining = computed(() => {
-  if (typeof props.budget?.remainingTokens === 'number' && !isLlmScope.value) {
+  if (typeof props.budget?.remainingTokens === 'number') {
     return props.budget.remainingTokens;
   }
   return Math.max(0, max.value - used.value);
@@ -45,7 +38,7 @@ const usedPercent = computed(() => (max.value > 0 ? Math.min(100, (used.value / 
 const scopeLabel = computed(() => {
   switch (props.budget?.scope) {
     case 'llm':
-      return 'LLM-Kontextfenster (letzte Anfrage)';
+      return 'Anbieter-Quota (weich)';
     case 'tenant':
       return 'Tenant-Limit';
     case 'user':
@@ -57,7 +50,8 @@ const scopeLabel = computed(() => {
 
 const resetAt = computed(() => (props.budget?.resetAt ? new Date(props.budget.resetAt).toLocaleString('de-DE') : ''));
 
-// Color logic: green up to 50%, amber 50–85%, red above
+// Color logic: green up to 50%, amber 50–85%, red above. For the LLM-soft scope
+// we still color-code but the bar represents a guideline, not a hard cutoff.
 const barClass = computed(() => {
   if (usedPercent.value >= 85) return 'bg-red-500';
   if (usedPercent.value >= 50) return 'bg-amber-500';
@@ -67,13 +61,12 @@ const barClass = computed(() => {
 const visible = computed(() => max.value > 0);
 
 const tooltipText = computed(() => {
-  const usedLabel = isLlmScope.value ? 'Letzte Anfrage' : 'Verbraucht';
   const lines = [
     `${scopeLabel.value}: ${max.value.toLocaleString('de-DE')} Tokens`,
-    `${usedLabel}: ${used.value.toLocaleString('de-DE')} (${usedPercent.value.toFixed(1)}%)`,
+    `Kumulativ${isLlmScope.value ? ' (weiches Limit)' : ''}: ${used.value.toLocaleString('de-DE')} (${usedPercent.value.toFixed(1)}%)`,
     `Übrig: ${remaining.value.toLocaleString('de-DE')}`,
   ];
-  if (resetAt.value && !isLlmScope.value) lines.push(`Reset: ${resetAt.value}`);
+  if (resetAt.value) lines.push(`Reset: ${resetAt.value}`);
   return lines.join('\n');
 });
 </script>

--- a/nuxt-base-template/app/components/Ai/AiTokenBar.vue
+++ b/nuxt-base-template/app/components/Ai/AiTokenBar.vue
@@ -7,6 +7,11 @@
 // Tenant-Limit → LLM-Context-Window. Wenn `maxTokens` nicht gesetzt ist, gibt es
 // kein effektives Limit → die Komponente rendert nichts.
 //
+// Wenn `scope === 'llm'` (kein echtes Budget, nur Context-Window), zeigt der
+// Balken die Tokens der LETZTEN Anfrage gegen das Context-Window — kumulativer
+// `usedTokens` ist hier per Definition immer 0, der relevante Wert ist
+// `promptTokens`. Bei user/tenant zählt der kumulierte Periodenverbrauch.
+//
 // Tooltip auf Hover zeigt die exakten Zahlen, das Scope-Label und den Reset-Zeitpunkt.
 // ============================================================================
 import type { LtAiBudgetSummary } from '@lenne.tech/nuxt-extensions';
@@ -15,15 +20,32 @@ const props = defineProps<{
   budget?: LtAiBudgetSummary | null;
 }>();
 
+const isLlmScope = computed(() => props.budget?.scope === 'llm');
 const max = computed(() => (typeof props.budget?.maxTokens === 'number' ? props.budget.maxTokens : 0));
-const used = computed(() => (typeof props.budget?.usedTokens === 'number' ? props.budget.usedTokens : 0));
-const remaining = computed(() => (typeof props.budget?.remainingTokens === 'number' ? props.budget.remainingTokens : Math.max(0, max.value - used.value)));
+
+// For LLM-context-window scope, the bar shows the LAST request against the window
+// (cumulative `usedTokens` is always 0 in that case). For user/tenant budgets it's
+// the running per-period total.
+const used = computed(() => {
+  if (isLlmScope.value) {
+    return typeof props.budget?.promptTokens === 'number' ? props.budget.promptTokens : 0;
+  }
+  return typeof props.budget?.usedTokens === 'number' ? props.budget.usedTokens : 0;
+});
+
+const remaining = computed(() => {
+  if (typeof props.budget?.remainingTokens === 'number' && !isLlmScope.value) {
+    return props.budget.remainingTokens;
+  }
+  return Math.max(0, max.value - used.value);
+});
+
 const usedPercent = computed(() => (max.value > 0 ? Math.min(100, (used.value / max.value) * 100) : 0));
 
 const scopeLabel = computed(() => {
   switch (props.budget?.scope) {
     case 'llm':
-      return 'LLM-Kontextfenster';
+      return 'LLM-Kontextfenster (letzte Anfrage)';
     case 'tenant':
       return 'Tenant-Limit';
     case 'user':
@@ -45,24 +67,25 @@ const barClass = computed(() => {
 const visible = computed(() => max.value > 0);
 
 const tooltipText = computed(() => {
+  const usedLabel = isLlmScope.value ? 'Letzte Anfrage' : 'Verbraucht';
   const lines = [
     `${scopeLabel.value}: ${max.value.toLocaleString('de-DE')} Tokens`,
-    `Verbraucht: ${used.value.toLocaleString('de-DE')} (${usedPercent.value.toFixed(1)}%)`,
+    `${usedLabel}: ${used.value.toLocaleString('de-DE')} (${usedPercent.value.toFixed(1)}%)`,
     `Übrig: ${remaining.value.toLocaleString('de-DE')}`,
   ];
-  if (resetAt.value) lines.push(`Reset: ${resetAt.value}`);
+  if (resetAt.value && !isLlmScope.value) lines.push(`Reset: ${resetAt.value}`);
   return lines.join('\n');
 });
 </script>
 
 <template>
   <UTooltip v-if="visible" :text="tooltipText" :delay-duration="100">
-    <div class="flex items-center gap-2" :aria-label="tooltipText">
+    <div class="flex items-center gap-2">
       <UIcon name="i-lucide-coins" class="size-4 shrink-0 text-muted" />
       <div class="relative h-2 w-32 overflow-hidden rounded-full bg-elevated">
         <div class="h-full rounded-full transition-all" :class="barClass" :style="{ width: usedPercent + '%' }" />
       </div>
-      <span class="text-xs text-muted tabular-nums"> {{ used.toLocaleString('de-DE') }} / {{ max.toLocaleString('de-DE') }} </span>
+      <span class="text-xs text-muted tabular-nums">{{ used.toLocaleString('de-DE') }} / {{ max.toLocaleString('de-DE') }}</span>
     </div>
   </UTooltip>
 </template>

--- a/nuxt-base-template/app/components/Ai/AiTokenBar.vue
+++ b/nuxt-base-template/app/components/Ai/AiTokenBar.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 // ============================================================================
-// Token-Usage-Balken — visualisiert den KUMULATIVEN Tokenverbrauch des Nutzers
-// im aktuellen Zeitraum gegen das aktuelle Limit.
+// Token-Usage-Balken — kumulativer Verbrauch im aktuellen Zeitraum gegen das
+// aktuelle Limit. Klick öffnet ein Popover mit allen Details (Quelle des
+// Limits, kumulativ verbraucht, verbleibend, letzte Anfrage, Reset).
 //
 // Limit-Resolution (Backend liefert das bereits aufgelöst):
 //   1. Nutzer-Limit (admin-konfiguriert; harte Sperre via 429)
@@ -10,11 +11,9 @@
 //      weiches Default für scope='llm')
 //   4. LLM-Kontextfenster (allerletzter Fallback; scope='llm')
 //
-// `usedTokens` ist IMMER der kumulierte Periodenverbrauch des Nutzers — auch
-// bei scope='llm'. Wenn `maxTokens` nicht gesetzt ist (kein Limit irgendeiner
-// Art), rendert die Komponente nichts.
-//
-// Tooltip auf Hover zeigt die exakten Zahlen, das Scope-Label und den Reset-Zeitpunkt.
+// `usedTokens` ist IMMER der kumulierte Periodenverbrauch — auch bei scope='llm'.
+// Wenn `maxTokens` nicht gesetzt ist (kein Limit irgendeiner Art), rendert die
+// Komponente nichts.
 // ============================================================================
 import type { LtAiBudgetSummary } from '@lenne.tech/nuxt-extensions';
 
@@ -25,6 +24,7 @@ const props = defineProps<{
 const isLlmScope = computed(() => props.budget?.scope === 'llm');
 const max = computed(() => (typeof props.budget?.maxTokens === 'number' ? props.budget.maxTokens : 0));
 const used = computed(() => (typeof props.budget?.usedTokens === 'number' ? props.budget.usedTokens : 0));
+const lastRequest = computed(() => (typeof props.budget?.promptTokens === 'number' ? props.budget.promptTokens : 0));
 
 const remaining = computed(() => {
   if (typeof props.budget?.remainingTokens === 'number') {
@@ -48,10 +48,22 @@ const scopeLabel = computed(() => {
   }
 });
 
+const scopeDescription = computed(() => {
+  switch (props.budget?.scope) {
+    case 'llm':
+      return 'Vom Anbieter / Kontextfenster abgeleitete weiche Obergrenze — kein hartes 429.';
+    case 'tenant':
+      return 'Vom Admin konfiguriertes Token-Limit pro Tenant. Bei Überschreitung antwortet das Backend mit 429.';
+    case 'user':
+      return 'Vom Admin konfiguriertes Token-Limit pro Nutzer. Bei Überschreitung antwortet das Backend mit 429.';
+    default:
+      return '';
+  }
+});
+
 const resetAt = computed(() => (props.budget?.resetAt ? new Date(props.budget.resetAt).toLocaleString('de-DE') : ''));
 
-// Color logic: green up to 50%, amber 50–85%, red above. For the LLM-soft scope
-// we still color-code but the bar represents a guideline, not a hard cutoff.
+// Color logic: green up to 50%, amber 50–85%, red above.
 const barClass = computed(() => {
   if (usedPercent.value >= 85) return 'bg-red-500';
   if (usedPercent.value >= 50) return 'bg-amber-500';
@@ -60,25 +72,54 @@ const barClass = computed(() => {
 
 const visible = computed(() => max.value > 0);
 
-const tooltipText = computed(() => {
-  const lines = [
-    `${scopeLabel.value}: ${max.value.toLocaleString('de-DE')} Tokens`,
-    `Kumulativ${isLlmScope.value ? ' (weiches Limit)' : ''}: ${used.value.toLocaleString('de-DE')} (${usedPercent.value.toFixed(1)}%)`,
-    `Übrig: ${remaining.value.toLocaleString('de-DE')}`,
-  ];
-  if (resetAt.value) lines.push(`Reset: ${resetAt.value}`);
-  return lines.join('\n');
-});
+function fmt(n: number): string {
+  return n.toLocaleString('de-DE');
+}
 </script>
 
 <template>
-  <UTooltip v-if="visible" :text="tooltipText" :delay-duration="100">
-    <div class="flex items-center gap-2">
+  <UPopover v-if="visible" :ui="{ content: 'w-80' }">
+    <button
+      type="button"
+      class="flex cursor-pointer items-center gap-2 rounded outline-none transition-opacity hover:opacity-80 focus-visible:ring-2 focus-visible:ring-primary"
+      aria-label="Token-Verbrauch anzeigen"
+    >
       <UIcon name="i-lucide-coins" class="size-4 shrink-0 text-muted" />
       <div class="relative h-2 w-32 overflow-hidden rounded-full bg-elevated">
         <div class="h-full rounded-full transition-all" :class="barClass" :style="{ width: usedPercent + '%' }" />
       </div>
-      <span class="text-xs text-muted tabular-nums">{{ used.toLocaleString('de-DE') }} / {{ max.toLocaleString('de-DE') }}</span>
-    </div>
-  </UTooltip>
+      <span class="text-xs text-muted tabular-nums">{{ fmt(used) }} / {{ fmt(max) }}</span>
+      <UIcon name="i-lucide-info" class="size-3 text-muted" />
+    </button>
+    <template #content>
+      <div class="p-4 text-sm">
+        <p class="mb-1 font-semibold">{{ scopeLabel }}</p>
+        <p v-if="scopeDescription" class="mb-3 text-xs text-muted">{{ scopeDescription }}</p>
+        <dl class="space-y-2">
+          <div class="flex items-baseline justify-between gap-3">
+            <dt class="text-muted">Limit</dt>
+            <dd class="tabular-nums font-medium">{{ fmt(max) }}</dd>
+          </div>
+          <div class="flex items-baseline justify-between gap-3">
+            <dt class="text-muted">Verbraucht (kumulativ)</dt>
+            <dd class="tabular-nums font-medium">
+              {{ fmt(used) }} <span class="text-muted">({{ usedPercent.toFixed(1) }}%)</span>
+            </dd>
+          </div>
+          <div class="flex items-baseline justify-between gap-3">
+            <dt class="text-muted">Übrig</dt>
+            <dd class="tabular-nums font-medium">{{ fmt(remaining) }}</dd>
+          </div>
+          <div class="flex items-baseline justify-between gap-3 border-t pt-2">
+            <dt class="text-muted">Letzte Anfrage</dt>
+            <dd class="tabular-nums font-medium">{{ fmt(lastRequest) }}</dd>
+          </div>
+          <div v-if="resetAt" class="flex items-baseline justify-between gap-3">
+            <dt class="text-muted">{{ isLlmScope ? 'Periode endet' : 'Reset' }}</dt>
+            <dd class="text-xs">{{ resetAt }}</dd>
+          </div>
+        </dl>
+      </div>
+    </template>
+  </UPopover>
 </template>

--- a/nuxt-base-template/app/components/Ai/AiTokenBar.vue
+++ b/nuxt-base-template/app/components/Ai/AiTokenBar.vue
@@ -1,19 +1,18 @@
 <script setup lang="ts">
 // ============================================================================
-// Token-Usage-Balken — kumulativer Verbrauch im aktuellen Zeitraum gegen das
-// aktuelle Limit. Klick öffnet ein Popover mit allen Details (Quelle des
-// Limits, kumulativ verbraucht, verbleibend, letzte Anfrage, Reset).
+// Token usage bar — cumulative period usage against the current limit. A
+// click opens a popover with all details (source of the limit, cumulative
+// usage, remaining, last request, reset).
 //
-// Limit-Resolution (Backend liefert das bereits aufgelöst):
-//   1. Nutzer-Limit (admin-konfiguriert; harte Sperre via 429)
-//   2. Tenant-Limit (admin-konfiguriert; harte Sperre via 429)
-//   3. Anbieter-Quota (`connection.defaultUserMaxTokens`, admin-gepflegt;
-//      weiches Default für scope='llm')
-//   4. LLM-Kontextfenster (allerletzter Fallback; scope='llm')
+// Limit resolution (the backend resolves this; the bar just renders it):
+//   1. User limit       (admin-configured; hard 429 on overflow)
+//   2. Tenant limit     (admin-configured; hard 429 on overflow)
+//   3. Provider quota   (`connection.defaultUserMaxTokens`, admin-pinned;
+//                        soft default for scope='llm')
+//   4. LLM context window  (last-resort soft default; scope='llm')
 //
-// `usedTokens` ist IMMER der kumulierte Periodenverbrauch — auch bei scope='llm'.
-// Wenn `maxTokens` nicht gesetzt ist (kein Limit irgendeiner Art), rendert die
-// Komponente nichts.
+// `usedTokens` is ALWAYS the running per-period total — including scope='llm'.
+// When `maxTokens` isn't set (no limit of any kind) the component renders nothing.
 // ============================================================================
 import type { LtAiBudgetSummary } from '@lenne.tech/nuxt-extensions';
 

--- a/nuxt-base-template/app/components/Ai/AiUsageBadge.vue
+++ b/nuxt-base-template/app/components/Ai/AiUsageBadge.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 // ============================================================================
-// Token-usage badge — zeigt den Verbrauch der LETZTEN Anfrage (promptTokens).
-// Der kumulierte Periodenverbrauch (usedTokens) wird vom Token-Bar abgedeckt.
-// Tooltip zeigt das Reset-Datum, wenn eine Periode aktiv ist.
+// Token usage badge — shows the LAST request's cost (`promptTokens`). The
+// running per-period total (`usedTokens`) belongs to the token bar.
+// Tooltip surfaces the period reset time when one is active.
 // ============================================================================
 import type { LtAiBudgetSummary } from '@lenne.tech/nuxt-extensions';
 

--- a/nuxt-base-template/app/components/Ai/AiUsageBadge.vue
+++ b/nuxt-base-template/app/components/Ai/AiUsageBadge.vue
@@ -1,0 +1,31 @@
+<script setup lang="ts">
+// ============================================================================
+// Props
+// ============================================================================
+import type { LtAiBudgetSummary } from '@lenne.tech/nuxt-extensions';
+
+const props = defineProps<{
+  budget?: LtAiBudgetSummary | null;
+}>();
+
+// ============================================================================
+// Computed
+// ============================================================================
+const hasLimit = computed(() => typeof props.budget?.remainingTokens === 'number');
+
+const resetLabel = computed(() => {
+  if (!props.budget?.resetAt) {
+    return '';
+  }
+  return new Date(props.budget.resetAt).toLocaleString('de-DE');
+});
+</script>
+
+<template>
+  <UTooltip v-if="budget" :text="resetLabel ? `Zurücksetzung: ${resetLabel}` : 'Token-Verbrauch'">
+    <UBadge color="neutral" variant="subtle" icon="i-lucide-coins">
+      <template v-if="hasLimit"> {{ budget.remainingTokens }} Tokens übrig </template>
+      <template v-else> {{ budget.usedTokens ?? 0 }} Tokens verbraucht </template>
+    </UBadge>
+  </UTooltip>
+</template>

--- a/nuxt-base-template/app/components/Ai/AiUsageBadge.vue
+++ b/nuxt-base-template/app/components/Ai/AiUsageBadge.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 // ============================================================================
-// Token-usage badge. The server only sends a finite `remainingTokens`/`usedTokens`
-// when a budget limit applies. For unlimited users it sends just `promptTokens`
-// (the last turn's cost), so fall back to that instead of showing "0 verbraucht".
+// Token-usage badge — zeigt den Verbrauch der LETZTEN Anfrage (promptTokens).
+// Der kumulierte Periodenverbrauch (usedTokens) wird vom Token-Bar abgedeckt.
+// Tooltip zeigt das Reset-Datum, wenn eine Periode aktiv ist.
 // ============================================================================
 import type { LtAiBudgetSummary } from '@lenne.tech/nuxt-extensions';
 
@@ -10,24 +10,12 @@ const props = defineProps<{
   budget?: LtAiBudgetSummary | null;
 }>();
 
-// ============================================================================
-// Computed
-// ============================================================================
 const label = computed(() => {
-  const b = props.budget;
-  if (!b) {
+  const tokens = props.budget?.promptTokens;
+  if (typeof tokens !== 'number') {
     return '';
   }
-  if (typeof b.remainingTokens === 'number') {
-    return `${b.remainingTokens} Tokens übrig`;
-  }
-  if (typeof b.usedTokens === 'number') {
-    return `${b.usedTokens} Tokens verbraucht`;
-  }
-  if (typeof b.promptTokens === 'number') {
-    return `${b.promptTokens} Tokens (letzte Anfrage)`;
-  }
-  return '';
+  return `${tokens.toLocaleString('de-DE')} Tokens (letzte Anfrage)`;
 });
 
 const resetLabel = computed(() => {
@@ -39,7 +27,7 @@ const resetLabel = computed(() => {
 </script>
 
 <template>
-  <UTooltip v-if="label" :text="resetLabel ? `Zurücksetzung: ${resetLabel}` : 'Token-Verbrauch'">
+  <UTooltip v-if="label" :text="resetLabel ? `Periode endet: ${resetLabel}` : 'Tokens der letzten Anfrage'">
     <UBadge color="neutral" variant="subtle" icon="i-lucide-coins">{{ label }}</UBadge>
   </UTooltip>
 </template>

--- a/nuxt-base-template/app/components/Ai/AiUsageBadge.vue
+++ b/nuxt-base-template/app/components/Ai/AiUsageBadge.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
 // ============================================================================
-// Props
+// Token-usage badge. The server only sends a finite `remainingTokens`/`usedTokens`
+// when a budget limit applies. For unlimited users it sends just `promptTokens`
+// (the last turn's cost), so fall back to that instead of showing "0 verbraucht".
 // ============================================================================
 import type { LtAiBudgetSummary } from '@lenne.tech/nuxt-extensions';
 
@@ -11,7 +13,22 @@ const props = defineProps<{
 // ============================================================================
 // Computed
 // ============================================================================
-const hasLimit = computed(() => typeof props.budget?.remainingTokens === 'number');
+const label = computed(() => {
+  const b = props.budget;
+  if (!b) {
+    return '';
+  }
+  if (typeof b.remainingTokens === 'number') {
+    return `${b.remainingTokens} Tokens übrig`;
+  }
+  if (typeof b.usedTokens === 'number') {
+    return `${b.usedTokens} Tokens verbraucht`;
+  }
+  if (typeof b.promptTokens === 'number') {
+    return `${b.promptTokens} Tokens (letzte Anfrage)`;
+  }
+  return '';
+});
 
 const resetLabel = computed(() => {
   if (!props.budget?.resetAt) {
@@ -22,10 +39,7 @@ const resetLabel = computed(() => {
 </script>
 
 <template>
-  <UTooltip v-if="budget" :text="resetLabel ? `Zurücksetzung: ${resetLabel}` : 'Token-Verbrauch'">
-    <UBadge color="neutral" variant="subtle" icon="i-lucide-coins">
-      <template v-if="hasLimit"> {{ budget.remainingTokens }} Tokens übrig </template>
-      <template v-else> {{ budget.usedTokens ?? 0 }} Tokens verbraucht </template>
-    </UBadge>
+  <UTooltip v-if="label" :text="resetLabel ? `Zurücksetzung: ${resetLabel}` : 'Token-Verbrauch'">
+    <UBadge color="neutral" variant="subtle" icon="i-lucide-coins">{{ label }}</UBadge>
   </UTooltip>
 </template>

--- a/nuxt-base-template/app/components/Ai/ModalAiConnection.vue
+++ b/nuxt-base-template/app/components/Ai/ModalAiConnection.vue
@@ -1,0 +1,125 @@
+<script setup lang="ts">
+// ============================================================================
+// Create/edit an AI connection (admin). Capability flags are tri-state:
+// "Automatisch erkennen" leaves them undefined so the backend auto-detects
+// them by probing the endpoint. The API key uses patch semantics (empty leaves
+// it unchanged on edit).
+// ============================================================================
+import type { LtAiConnection, LtAiConnectionInput } from '@lenne.tech/nuxt-extensions';
+import type { FormSubmitEvent } from '@nuxt/ui';
+
+import * as v from 'valibot';
+
+const props = defineProps<{
+  connection?: LtAiConnection;
+}>();
+
+const emit = defineEmits<{
+  close: [saved?: boolean];
+}>();
+
+const admin = useLtAiAdmin();
+const toast = useToast();
+const loading = ref(false);
+const isEdit = computed(() => !!props.connection?.id);
+
+type TriState = 'auto' | 'no' | 'yes';
+const triItems = [
+  { label: 'Automatisch erkennen', value: 'auto' },
+  { label: 'Ja', value: 'yes' },
+  { label: 'Nein', value: 'no' },
+];
+
+function toTri(value?: boolean): TriState {
+  return value === undefined ? 'auto' : value ? 'yes' : 'no';
+}
+function fromTri(value: TriState): boolean | undefined {
+  return value === 'auto' ? undefined : value === 'yes';
+}
+
+const form = reactive({
+  apiKey: '',
+  baseUrl: props.connection?.baseUrl ?? '',
+  defaultMaxTokens: props.connection?.defaultMaxTokens,
+  isDefault: props.connection?.isDefault ?? false,
+  model: props.connection?.model ?? '',
+  name: props.connection?.name ?? '',
+  providerType: props.connection?.providerType ?? 'openai-compatible',
+  supportsJsonResponse: toTri(props.connection?.supportsJsonResponse),
+  supportsNativeTools: toTri(props.connection?.supportsNativeTools),
+});
+
+const schema = v.object({
+  baseUrl: v.pipe(v.string('Basis-URL ist erforderlich'), v.url('Ungültige URL')),
+  model: v.pipe(v.string('Modell ist erforderlich'), v.minLength(1, 'Modell ist erforderlich')),
+  name: v.pipe(v.string('Name ist erforderlich'), v.minLength(1, 'Name ist erforderlich')),
+});
+
+async function onSubmit(_event: FormSubmitEvent<v.InferOutput<typeof schema>>): Promise<void> {
+  loading.value = true;
+  try {
+    const input: LtAiConnectionInput = {
+      baseUrl: form.baseUrl,
+      defaultMaxTokens: form.defaultMaxTokens,
+      isDefault: form.isDefault,
+      model: form.model,
+      name: form.name,
+      providerType: form.providerType,
+      supportsJsonResponse: fromTri(form.supportsJsonResponse),
+      supportsNativeTools: fromTri(form.supportsNativeTools),
+    };
+    // Patch semantics: only send apiKey when the admin typed one.
+    if (form.apiKey) {
+      input.apiKey = form.apiKey;
+    }
+    if (isEdit.value && props.connection?.id) {
+      await admin.updateConnection(props.connection.id, input);
+    } else {
+      await admin.createConnection(input);
+    }
+    toast.add({ color: 'success', description: 'Verbindung gespeichert.', title: 'Erfolg' });
+    emit('close', true);
+  } catch (err) {
+    toast.add({ color: 'error', description: (err as Error).message, title: 'Fehler' });
+  } finally {
+    loading.value = false;
+  }
+}
+</script>
+
+<template>
+  <UModal :title="isEdit ? 'Verbindung bearbeiten' : 'Verbindung hinzufügen'" :close="{ onClick: () => emit('close', false) }">
+    <template #body>
+      <UForm :schema="schema" :state="form" class="space-y-4" @submit="onSubmit">
+        <UFormField label="Name" name="name" required>
+          <UInput v-model="form.name" placeholder="z.B. Default LLM" />
+        </UFormField>
+        <UFormField label="Basis-URL" name="baseUrl" required help="OpenAI-kompatibler Endpoint, z.B. https://llm.example.com/v1">
+          <UInput v-model="form.baseUrl" placeholder="https://llm.example.com/v1" />
+        </UFormField>
+        <UFormField label="Modell" name="model" required>
+          <UInput v-model="form.model" placeholder="z.B. gpt-oss-120b" />
+        </UFormField>
+        <UFormField label="API-Key" name="apiKey" :help="isEdit ? 'Leer lassen, um den vorhandenen Key zu behalten' : 'Optional — wird verschlüsselt gespeichert'">
+          <UInput v-model="form.apiKey" type="password" :placeholder="isEdit ? '•••••••• (unverändert)' : 'sk-…'" />
+        </UFormField>
+        <div class="grid grid-cols-2 gap-3">
+          <UFormField label="JSON-Modus" name="supportsJsonResponse">
+            <USelectMenu v-model="form.supportsJsonResponse" :items="triItems" value-key="value" />
+          </UFormField>
+          <UFormField label="Native Tools" name="supportsNativeTools">
+            <USelectMenu v-model="form.supportsNativeTools" :items="triItems" value-key="value" />
+          </UFormField>
+        </div>
+        <UFormField label="Max. Tokens" name="defaultMaxTokens">
+          <UInput v-model.number="form.defaultMaxTokens" type="number" placeholder="4096" />
+        </UFormField>
+        <UCheckbox v-model="form.isDefault" label="Als globalen Standard setzen" />
+        <div class="flex justify-end gap-3 pt-2">
+          <UButton color="neutral" variant="outline" @click="emit('close', false)"> Abbrechen </UButton>
+          <UButton type="submit" color="primary" :loading="loading"> Speichern </UButton>
+        </div>
+      </UForm>
+    </template>
+  </UModal>
+</template>

--- a/nuxt-base-template/app/components/Ai/ModalAiConnection.vue
+++ b/nuxt-base-template/app/components/Ai/ModalAiConnection.vue
@@ -30,6 +30,14 @@ const triItems = [
   { label: 'Nein', value: 'no' },
 ];
 
+// Provider backends. `openai-compatible` covers hosted (external) and local
+// (e.g. Ollama) endpoints; `claude-cli` drives the local Claude Code CLI and
+// needs no base URL (register ClaudeCliProvider on the backend factory).
+const providerItems = [
+  { label: 'OpenAI-kompatibel (extern / lokal)', value: 'openai-compatible' },
+  { label: 'Claude Code CLI (lokal)', value: 'claude-cli' },
+];
+
 function toTri(value?: boolean): TriState {
   return value === undefined ? 'auto' : value ? 'yes' : 'no';
 }
@@ -49,17 +57,28 @@ const form = reactive({
   supportsNativeTools: toTri(props.connection?.supportsNativeTools),
 });
 
+// CLI providers don't use a base URL; OpenAI-compatible ones require a valid URL.
+const isCliProvider = computed(() => form.providerType === 'claude-cli');
+
 const schema = v.object({
-  baseUrl: v.pipe(v.string('Basis-URL ist erforderlich'), v.url('Ungültige URL')),
+  // Allow empty (CLI) or a valid URL; the "required for OpenAI-compatible" rule is
+  // enforced in onSubmit so the message can reference the chosen provider.
+  baseUrl: v.union([v.literal(''), v.pipe(v.string(), v.url('Ungültige URL'))]),
   model: v.pipe(v.string('Modell ist erforderlich'), v.minLength(1, 'Modell ist erforderlich')),
   name: v.pipe(v.string('Name ist erforderlich'), v.minLength(1, 'Name ist erforderlich')),
 });
 
 async function onSubmit(_event: FormSubmitEvent<v.InferOutput<typeof schema>>): Promise<void> {
+  if (!isCliProvider.value && !form.baseUrl) {
+    toast.add({ color: 'error', description: 'Basis-URL ist für OpenAI-kompatible Verbindungen erforderlich.', title: 'Fehler' });
+    return;
+  }
   loading.value = true;
   try {
     const input: LtAiConnectionInput = {
-      baseUrl: form.baseUrl,
+      // CLI backends ignore the base URL; send a stable placeholder so the
+      // required backend field is satisfied.
+      baseUrl: isCliProvider.value ? form.baseUrl || 'cli://claude-code' : form.baseUrl,
       defaultMaxTokens: form.defaultMaxTokens,
       isDefault: form.isDefault,
       model: form.model,
@@ -94,11 +113,20 @@ async function onSubmit(_event: FormSubmitEvent<v.InferOutput<typeof schema>>): 
         <UFormField label="Name" name="name" required>
           <UInput v-model="form.name" placeholder="z.B. Default LLM" />
         </UFormField>
-        <UFormField label="Basis-URL" name="baseUrl" required help="OpenAI-kompatibler Endpoint, z.B. https://llm.example.com/v1">
+        <UFormField label="Provider" name="providerType" help="Backend-Art der Verbindung">
+          <USelectMenu v-model="form.providerType" :items="providerItems" value-key="value" class="w-full" />
+        </UFormField>
+        <UFormField
+          v-if="!isCliProvider"
+          label="Basis-URL"
+          name="baseUrl"
+          required
+          help="OpenAI-kompatibler Endpoint, z.B. https://llm.example.com/v1 oder http://localhost:11434/v1 (Ollama)"
+        >
           <UInput v-model="form.baseUrl" placeholder="https://llm.example.com/v1" />
         </UFormField>
-        <UFormField label="Modell" name="model" required>
-          <UInput v-model="form.model" placeholder="z.B. gpt-oss-120b" />
+        <UFormField label="Modell" name="model" required :help="isCliProvider ? 'Claude-Alias, z.B. sonnet, opus oder haiku' : undefined">
+          <UInput v-model="form.model" :placeholder="isCliProvider ? 'z.B. sonnet' : 'z.B. gpt-oss-120b'" />
         </UFormField>
         <UFormField label="API-Key" name="apiKey" :help="isEdit ? 'Leer lassen, um den vorhandenen Key zu behalten' : 'Optional — wird verschlüsselt gespeichert'">
           <UInput v-model="form.apiKey" type="password" :placeholder="isEdit ? '•••••••• (unverändert)' : 'sk-…'" />

--- a/nuxt-base-template/app/layouts/default.vue
+++ b/nuxt-base-template/app/layouts/default.vue
@@ -26,6 +26,7 @@ const headerItems = computed<NavigationMenuItem[]>(() => {
   }
   const items: NavigationMenuItem[] = [
     { icon: 'i-lucide-sparkles', label: 'KI-Assistent', to: '/app/ai' },
+    { icon: 'i-lucide-clipboard-list', label: 'KI-Vorlagen', to: '/app/settings/ai-snippets' },
     { icon: 'i-lucide-settings', label: 'KI-Einstellungen', to: '/app/settings/ai' },
   ];
   if (isAdmin.value) {

--- a/nuxt-base-template/app/layouts/default.vue
+++ b/nuxt-base-template/app/layouts/default.vue
@@ -12,13 +12,7 @@ async function handleLogout() {
   await navigateTo('/auth/login');
 }
 
-// nest-server users carry roles as an array (`roles: string[]`); some Better Auth
-// setups additionally expose a singular `role`. Accept either so the admin nav
-// shows up regardless of the auth shape.
-const isAdmin = computed(() => {
-  const u = user.value as { role?: string; roles?: string[] } | null;
-  return !!u?.roles?.includes('admin') || u?.role === 'admin';
-});
+const isAdmin = computed(() => isAdminUser(user.value));
 
 const headerItems = computed<NavigationMenuItem[]>(() => {
   if (!isAuthenticated.value) {

--- a/nuxt-base-template/app/layouts/default.vue
+++ b/nuxt-base-template/app/layouts/default.vue
@@ -12,26 +12,21 @@ async function handleLogout() {
   await navigateTo('/auth/login');
 }
 
-const headerItems = computed<NavigationMenuItem[]>(() => [
-  {
-    label: 'Docs',
-    to: '#',
-  },
-  {
-    label: 'Components',
-    to: '#',
-  },
-  {
-    label: 'Figma',
-    target: '_blank',
-    to: '#',
-  },
-  {
-    label: 'Releases',
-    target: '_blank',
-    to: '#',
-  },
-]);
+const isAdmin = computed(() => (user.value as { role?: string } | null)?.role === 'admin');
+
+const headerItems = computed<NavigationMenuItem[]>(() => {
+  if (!isAuthenticated.value) {
+    return [{ label: 'Docs', to: '#' }];
+  }
+  const items: NavigationMenuItem[] = [
+    { icon: 'i-lucide-sparkles', label: 'KI-Assistent', to: '/app/ai' },
+    { icon: 'i-lucide-settings', label: 'KI-Einstellungen', to: '/app/settings/ai' },
+  ];
+  if (isAdmin.value) {
+    items.push({ icon: 'i-lucide-shield', label: 'Administration', to: '/app/admin' });
+  }
+  return items;
+});
 
 const footerItems: NavigationMenuItem[] = [
   {

--- a/nuxt-base-template/app/layouts/default.vue
+++ b/nuxt-base-template/app/layouts/default.vue
@@ -12,7 +12,13 @@ async function handleLogout() {
   await navigateTo('/auth/login');
 }
 
-const isAdmin = computed(() => (user.value as { role?: string } | null)?.role === 'admin');
+// nest-server users carry roles as an array (`roles: string[]`); some Better Auth
+// setups additionally expose a singular `role`. Accept either so the admin nav
+// shows up regardless of the auth shape.
+const isAdmin = computed(() => {
+  const u = user.value as { role?: string; roles?: string[] } | null;
+  return !!u?.roles?.includes('admin') || u?.role === 'admin';
+});
 
 const headerItems = computed<NavigationMenuItem[]>(() => {
   if (!isAuthenticated.value) {

--- a/nuxt-base-template/app/layouts/default.vue
+++ b/nuxt-base-template/app/layouts/default.vue
@@ -26,7 +26,7 @@ const headerItems = computed<NavigationMenuItem[]>(() => {
   }
   const items: NavigationMenuItem[] = [
     { icon: 'i-lucide-sparkles', label: 'KI-Assistent', to: '/app/ai' },
-    { icon: 'i-lucide-clipboard-list', label: 'KI-Vorlagen', to: '/app/settings/ai-snippets' },
+    { icon: 'i-lucide-clipboard-list', label: 'KI-Vorlagen', to: '/app/settings/ai-prompts' },
     { icon: 'i-lucide-settings', label: 'KI-Einstellungen', to: '/app/settings/ai' },
   ];
   if (isAdmin.value) {

--- a/nuxt-base-template/app/middleware/admin.global.ts
+++ b/nuxt-base-template/app/middleware/admin.global.ts
@@ -1,3 +1,9 @@
+// nest-server users carry roles as an array (`roles: string[]`); some Better Auth
+// setups additionally expose a singular `role`. Accept either.
+function isAdminUser(user: { role?: string; roles?: string[] } | null | undefined): boolean {
+  return !!user?.roles?.includes('admin') || user?.role === 'admin';
+}
+
 export default defineNuxtRouteMiddleware(async (to) => {
   // Only check routes starting with /app/admin
   if (!to.path.startsWith('/app/admin')) {
@@ -21,16 +27,16 @@ export default defineNuxtRouteMiddleware(async (to) => {
         const value = parts.length > 1 ? decodeURIComponent(parts.slice(1).join('=')) : '';
         const state = JSON.parse(value);
         isAuthenticated = !!state?.user;
-        isAdmin = state?.user?.role === 'admin';
+        isAdmin = isAdminUser(state?.user);
       }
     } catch {
       // Ignore parse errors
     }
   } else {
     // On server, use useCookie
-    const authStateCookie = useCookie<{ user: { role?: string } | null; authMode: string } | null>(cookieName);
+    const authStateCookie = useCookie<{ authMode: string; user: { role?: string; roles?: string[] } | null } | null>(cookieName);
     isAuthenticated = !!authStateCookie.value?.user;
-    isAdmin = authStateCookie.value?.user?.role === 'admin';
+    isAdmin = isAdminUser(authStateCookie.value?.user);
   }
 
   // Redirect to login if not authenticated

--- a/nuxt-base-template/app/middleware/admin.global.ts
+++ b/nuxt-base-template/app/middleware/admin.global.ts
@@ -1,8 +1,6 @@
-// nest-server users carry roles as an array (`roles: string[]`); some Better Auth
-// setups additionally expose a singular `role`. Accept either.
-function isAdminUser(user: { role?: string; roles?: string[] } | null | undefined): boolean {
-  return !!user?.roles?.includes('admin') || user?.role === 'admin';
-}
+// `isAdminUser` is the project's single source of truth for the dual-shape
+// role check (`role: string` vs `roles: string[]`) — see app/utils/is-admin-user.ts.
+// It is auto-imported by Nuxt.
 
 export default defineNuxtRouteMiddleware(async (to) => {
   // Only check routes starting with /app/admin

--- a/nuxt-base-template/app/pages/app/admin/ai/budgets.vue
+++ b/nuxt-base-template/app/pages/app/admin/ai/budgets.vue
@@ -1,0 +1,111 @@
+<script setup lang="ts">
+// ============================================================================
+// Admin: AI budget limits (per user/tenant token & prompt caps).
+// ============================================================================
+import type { LtAiBudgetLimit } from '@lenne.tech/nuxt-extensions';
+
+useHead({ title: 'KI-Budgets' });
+
+const admin = useLtAiAdmin();
+const toast = useToast();
+
+const limits = ref<LtAiBudgetLimit[]>([]);
+const loading = ref(false);
+const saving = ref(false);
+
+const scopeItems = [
+  { label: 'Nutzer', value: 'user' },
+  { label: 'Tenant', value: 'tenant' },
+];
+const periodItems = [
+  { label: 'Tag', value: 'day' },
+  { label: 'Monat', value: 'month' },
+  { label: 'Ohne Reset', value: 'none' },
+];
+
+const form = reactive<LtAiBudgetLimit>({ maxPrompts: undefined, maxTokens: undefined, period: 'day', refId: '', scope: 'user' });
+
+onMounted(load);
+
+async function load(): Promise<void> {
+  loading.value = true;
+  try {
+    limits.value = await admin.listBudgetLimits();
+  } catch (err) {
+    toast.add({ color: 'error', description: (err as Error).message, title: 'Fehler' });
+  } finally {
+    loading.value = false;
+  }
+}
+
+async function create(): Promise<void> {
+  if (!form.refId.trim()) {
+    toast.add({ color: 'error', description: 'Bitte eine Referenz-ID (Nutzer-/Tenant-ID) angeben.', title: 'Fehler' });
+    return;
+  }
+  saving.value = true;
+  try {
+    await admin.createBudgetLimit({ ...form });
+    toast.add({ color: 'success', description: 'Budget gespeichert.', title: 'Erfolg' });
+    form.refId = '';
+    form.maxTokens = undefined;
+    form.maxPrompts = undefined;
+    await load();
+  } catch (err) {
+    toast.add({ color: 'error', description: (err as Error).message, title: 'Fehler' });
+  } finally {
+    saving.value = false;
+  }
+}
+
+async function remove(limit: LtAiBudgetLimit): Promise<void> {
+  if (!limit.id) {
+    return;
+  }
+  try {
+    await admin.deleteBudgetLimit(limit.id);
+    toast.add({ color: 'success', description: 'Budget gelöscht.', title: 'Erfolg' });
+    await load();
+  } catch (err) {
+    toast.add({ color: 'error', description: (err as Error).message, title: 'Fehler' });
+  }
+}
+</script>
+
+<template>
+  <div class="mx-auto max-w-4xl space-y-6">
+    <div>
+      <h1 class="text-2xl font-bold">KI-Budgets</h1>
+      <p class="text-muted">Token- und Anfrage-Limits pro Nutzer oder Tenant (0/leer = unbegrenzt).</p>
+    </div>
+
+    <UCard>
+      <template #header><h2 class="font-semibold">Neues Limit</h2></template>
+      <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <UFormField label="Bereich"><USelectMenu v-model="form.scope" :items="scopeItems" value-key="value" /></UFormField>
+        <UFormField label="Zeitraum"><USelectMenu v-model="form.period" :items="periodItems" value-key="value" /></UFormField>
+        <UFormField label="Referenz-ID (Nutzer/Tenant)" class="sm:col-span-2"><UInput v-model="form.refId" placeholder="ObjectId" /></UFormField>
+        <UFormField label="Max. Tokens"><UInput v-model.number="form.maxTokens" type="number" placeholder="unbegrenzt" /></UFormField>
+        <UFormField label="Max. Anfragen"><UInput v-model.number="form.maxPrompts" type="number" placeholder="unbegrenzt" /></UFormField>
+      </div>
+      <template #footer><UButton icon="i-lucide-plus" :loading="saving" @click="create"> Limit anlegen </UButton></template>
+    </UCard>
+
+    <UCard>
+      <template #header><h2 class="font-semibold">Bestehende Limits</h2></template>
+      <div v-if="loading" class="py-8 text-center text-muted"><UIcon name="i-lucide-loader-circle" class="size-6 animate-spin" /></div>
+      <p v-else-if="!limits.length" class="py-8 text-center text-muted">Keine Limits konfiguriert.</p>
+      <div v-else class="divide-y">
+        <div v-for="limit in limits" :key="limit.id" class="flex items-center justify-between py-3">
+          <div>
+            <p class="font-medium">{{ limit.scope === 'user' ? 'Nutzer' : 'Tenant' }} · {{ limit.refId }}</p>
+            <p class="text-xs text-muted">
+              {{ limit.maxTokens || '∞' }} Tokens · {{ limit.maxPrompts || '∞' }} Anfragen · {{ limit.period }}
+            </p>
+          </div>
+          <UButton size="sm" variant="ghost" color="error" icon="i-lucide-trash" @click="remove(limit)" />
+        </div>
+      </div>
+    </UCard>
+  </div>
+</template>

--- a/nuxt-base-template/app/pages/app/admin/ai/budgets.vue
+++ b/nuxt-base-template/app/pages/app/admin/ai/budgets.vue
@@ -5,6 +5,7 @@
 import type { LtAiBudgetLimit } from '@lenne.tech/nuxt-extensions';
 
 useHead({ title: 'KI-Budgets' });
+definePageMeta({ ssr: false });
 
 const admin = useLtAiAdmin();
 const toast = useToast();

--- a/nuxt-base-template/app/pages/app/admin/ai/budgets.vue
+++ b/nuxt-base-template/app/pages/app/admin/ai/budgets.vue
@@ -99,9 +99,7 @@ async function remove(limit: LtAiBudgetLimit): Promise<void> {
         <div v-for="limit in limits" :key="limit.id" class="flex items-center justify-between py-3">
           <div>
             <p class="font-medium">{{ limit.scope === 'user' ? 'Nutzer' : 'Tenant' }} · {{ limit.refId }}</p>
-            <p class="text-xs text-muted">
-              {{ limit.maxTokens || '∞' }} Tokens · {{ limit.maxPrompts || '∞' }} Anfragen · {{ limit.period }}
-            </p>
+            <p class="text-xs text-muted">{{ limit.maxTokens || '∞' }} Tokens · {{ limit.maxPrompts || '∞' }} Anfragen · {{ limit.period }}</p>
           </div>
           <UButton size="sm" variant="ghost" color="error" icon="i-lucide-trash" @click="remove(limit)" />
         </div>

--- a/nuxt-base-template/app/pages/app/admin/ai/connections.vue
+++ b/nuxt-base-template/app/pages/app/admin/ai/connections.vue
@@ -8,6 +8,7 @@ import type { LtAiConnection } from '@lenne.tech/nuxt-extensions';
 import ModalAiConnection from '~/components/Ai/ModalAiConnection.vue';
 
 useHead({ title: 'KI-Verbindungen' });
+definePageMeta({ ssr: false });
 
 const admin = useLtAiAdmin();
 const overlay = useOverlay();

--- a/nuxt-base-template/app/pages/app/admin/ai/connections.vue
+++ b/nuxt-base-template/app/pages/app/admin/ai/connections.vue
@@ -1,0 +1,112 @@
+<script setup lang="ts">
+// ============================================================================
+// Admin: AI connection management (CRUD + capability auto-detection).
+// Protected by admin.global middleware (/app/admin/*).
+// ============================================================================
+import type { LtAiConnection } from '@lenne.tech/nuxt-extensions';
+
+import ModalAiConnection from '~/components/Ai/ModalAiConnection.vue';
+
+useHead({ title: 'KI-Verbindungen' });
+
+const admin = useLtAiAdmin();
+const overlay = useOverlay();
+const toast = useToast();
+
+const connections = ref<LtAiConnection[]>([]);
+const loading = ref(false);
+const busyId = ref<string | null>(null);
+
+onMounted(load);
+
+async function load(): Promise<void> {
+  loading.value = true;
+  try {
+    connections.value = await admin.listConnections();
+  } catch (err) {
+    toast.add({ color: 'error', description: (err as Error).message, title: 'Fehler' });
+  } finally {
+    loading.value = false;
+  }
+}
+
+async function openModal(connection?: LtAiConnection): Promise<void> {
+  const modal = overlay.create(ModalAiConnection, { props: { connection } });
+  const saved = await modal.open();
+  if (saved) {
+    await load();
+  }
+}
+
+async function detect(connection: LtAiConnection): Promise<void> {
+  busyId.value = connection.id;
+  try {
+    const updated = await admin.detectCapabilities(connection.id);
+    toast.add({
+      color: 'success',
+      description: `JSON: ${cap(updated.supportsJsonResponse)}, Tools: ${cap(updated.supportsNativeTools)}`,
+      title: 'Fähigkeiten erkannt',
+    });
+    await load();
+  } catch (err) {
+    toast.add({ color: 'error', description: (err as Error).message, title: 'Fehler' });
+  } finally {
+    busyId.value = null;
+  }
+}
+
+async function remove(connection: LtAiConnection): Promise<void> {
+  busyId.value = connection.id;
+  try {
+    await admin.deleteConnection(connection.id);
+    toast.add({ color: 'success', description: 'Verbindung gelöscht.', title: 'Erfolg' });
+    await load();
+  } catch (err) {
+    toast.add({ color: 'error', description: (err as Error).message, title: 'Fehler' });
+  } finally {
+    busyId.value = null;
+  }
+}
+
+function cap(value?: boolean): string {
+  return value === undefined ? 'auto' : value ? 'ja' : 'nein';
+}
+</script>
+
+<template>
+  <div class="mx-auto max-w-4xl space-y-6">
+    <div class="flex items-center justify-between">
+      <div>
+        <h1 class="text-2xl font-bold">KI-Verbindungen</h1>
+        <p class="text-muted">Verwalte die LLM-Verbindungen. Fähigkeiten werden bei leerer Angabe automatisch erkannt.</p>
+      </div>
+      <UButton icon="i-lucide-plus" @click="openModal()"> Verbindung hinzufügen </UButton>
+    </div>
+
+    <UCard>
+      <div v-if="loading" class="py-8 text-center text-muted"><UIcon name="i-lucide-loader-circle" class="size-6 animate-spin" /></div>
+      <p v-else-if="!connections.length" class="py-8 text-center text-muted">Noch keine Verbindungen.</p>
+      <div v-else class="divide-y">
+        <div v-for="conn in connections" :key="conn.id" class="flex items-center justify-between gap-3 py-3">
+          <div class="min-w-0">
+            <div class="flex items-center gap-2">
+              <p class="truncate font-medium">{{ conn.name }}</p>
+              <UBadge v-if="conn.isDefault" size="sm" color="primary" variant="subtle">Standard</UBadge>
+              <UBadge v-if="conn.enabled === false" size="sm" color="neutral" variant="subtle">Deaktiviert</UBadge>
+              <UBadge v-if="conn.hasApiKey" size="sm" color="success" variant="subtle" icon="i-lucide-key">Key</UBadge>
+            </div>
+            <p class="truncate text-xs text-muted">{{ conn.model }} · {{ conn.baseUrl }}</p>
+            <p class="text-xs text-muted">JSON: {{ cap(conn.supportsJsonResponse) }} · Tools: {{ cap(conn.supportsNativeTools) }}</p>
+          </div>
+          <div class="flex shrink-0 items-center gap-1">
+            <UTooltip text="Fähigkeiten erkennen">
+              <UButton size="sm" variant="ghost" icon="i-lucide-radar" :loading="busyId === conn.id" @click="detect(conn)" />
+            </UTooltip>
+            <UButton size="sm" variant="ghost" icon="i-lucide-pencil" @click="openModal(conn)" />
+            <UButton size="sm" variant="ghost" color="error" icon="i-lucide-trash" :loading="busyId === conn.id" @click="remove(conn)" />
+          </div>
+        </div>
+      </div>
+    </UCard>
+  </div>
+</template>

--- a/nuxt-base-template/app/pages/app/admin/ai/interactions.vue
+++ b/nuxt-base-template/app/pages/app/admin/ai/interactions.vue
@@ -1,0 +1,59 @@
+<script setup lang="ts">
+// ============================================================================
+// Admin: AI interaction audit log (read-only). Requires ai.audit on the backend.
+// ============================================================================
+import type { LtAiInteraction } from '@lenne.tech/nuxt-extensions';
+
+useHead({ title: 'KI-Audit-Log' });
+
+const admin = useLtAiAdmin();
+const toast = useToast();
+
+const interactions = ref<LtAiInteraction[]>([]);
+const loading = ref(false);
+
+onMounted(load);
+
+async function load(): Promise<void> {
+  loading.value = true;
+  try {
+    interactions.value = await admin.listInteractions();
+  } catch (err) {
+    toast.add({ color: 'error', description: (err as Error).message, title: 'Fehler' });
+  } finally {
+    loading.value = false;
+  }
+}
+</script>
+
+<template>
+  <div class="mx-auto max-w-4xl space-y-6">
+    <div class="flex items-center justify-between">
+      <div>
+        <h1 class="text-2xl font-bold">KI-Audit-Log</h1>
+        <p class="text-muted">Protokollierte Prompt-Läufe (nur bei aktiviertem Audit).</p>
+      </div>
+      <UButton variant="outline" icon="i-lucide-refresh-cw" :loading="loading" @click="load"> Aktualisieren </UButton>
+    </div>
+
+    <UCard>
+      <div v-if="loading" class="py-8 text-center text-muted"><UIcon name="i-lucide-loader-circle" class="size-6 animate-spin" /></div>
+      <p v-else-if="!interactions.length" class="py-8 text-center text-muted">Keine Einträge.</p>
+      <div v-else class="divide-y">
+        <div v-for="item in interactions" :key="item.id" class="space-y-1 py-3">
+          <div class="flex items-center justify-between gap-3">
+            <p class="truncate font-medium">{{ item.prompt || '—' }}</p>
+            <span class="shrink-0 text-xs text-muted">{{ item.createdAt ? new Date(item.createdAt).toLocaleString('de-DE') : '' }}</span>
+          </div>
+          <p class="truncate text-sm text-muted">{{ item.responseText }}</p>
+          <div class="flex flex-wrap gap-2 text-xs text-muted">
+            <span>{{ item.totalTokens ?? 0 }} Tokens</span>
+            <span v-if="item.iterations">· {{ item.iterations }} Iter.</span>
+            <span v-if="item.actions?.length">· {{ item.actions.length }} Aktion(en)</span>
+            <span v-if="item.userId">· Nutzer {{ item.userId }}</span>
+          </div>
+        </div>
+      </div>
+    </UCard>
+  </div>
+</template>

--- a/nuxt-base-template/app/pages/app/admin/ai/interactions.vue
+++ b/nuxt-base-template/app/pages/app/admin/ai/interactions.vue
@@ -5,6 +5,7 @@
 import type { LtAiInteraction } from '@lenne.tech/nuxt-extensions';
 
 useHead({ title: 'KI-Audit-Log' });
+definePageMeta({ ssr: false });
 
 const admin = useLtAiAdmin();
 const toast = useToast();

--- a/nuxt-base-template/app/pages/app/admin/ai/preferences.vue
+++ b/nuxt-base-template/app/pages/app/admin/ai/preferences.vue
@@ -5,6 +5,7 @@
 import type { LtAiConnection, LtAiConnectionPreference } from '@lenne.tech/nuxt-extensions';
 
 useHead({ title: 'KI-Verbindungs-Präferenzen' });
+definePageMeta({ ssr: false });
 
 const admin = useLtAiAdmin();
 const toast = useToast();

--- a/nuxt-base-template/app/pages/app/admin/ai/preferences.vue
+++ b/nuxt-base-template/app/pages/app/admin/ai/preferences.vue
@@ -1,0 +1,121 @@
+<script setup lang="ts">
+// ============================================================================
+// Admin: AI connection preferences (tenant/user defaults + tenant-enforced).
+// ============================================================================
+import type { LtAiConnection, LtAiConnectionPreference } from '@lenne.tech/nuxt-extensions';
+
+useHead({ title: 'KI-Verbindungs-Präferenzen' });
+
+const admin = useLtAiAdmin();
+const toast = useToast();
+
+const preferences = ref<LtAiConnectionPreference[]>([]);
+const connections = ref<LtAiConnection[]>([]);
+const loading = ref(false);
+const saving = ref(false);
+
+const scopeItems = [
+  { label: 'Tenant', value: 'tenant' },
+  { label: 'Nutzer', value: 'user' },
+];
+
+const form = reactive<LtAiConnectionPreference>({ connectionId: '', enforced: false, refId: '', scope: 'tenant' });
+
+const connectionItems = computed(() => connections.value.map((c) => ({ label: c.name || c.id, value: c.id })));
+
+onMounted(async () => {
+  await Promise.all([load(), loadConnections()]);
+});
+
+async function load(): Promise<void> {
+  loading.value = true;
+  try {
+    preferences.value = await admin.listPreferences();
+  } catch (err) {
+    toast.add({ color: 'error', description: (err as Error).message, title: 'Fehler' });
+  } finally {
+    loading.value = false;
+  }
+}
+
+async function loadConnections(): Promise<void> {
+  try {
+    connections.value = await admin.listConnections();
+  } catch {
+    // listing connections is best-effort for the picker
+  }
+}
+
+async function save(): Promise<void> {
+  if (!form.refId.trim() || !form.connectionId) {
+    toast.add({ color: 'error', description: 'Referenz-ID und Verbindung sind erforderlich.', title: 'Fehler' });
+    return;
+  }
+  saving.value = true;
+  try {
+    await admin.setPreference({ ...form, enforced: form.scope === 'tenant' ? form.enforced : false });
+    toast.add({ color: 'success', description: 'Präferenz gespeichert.', title: 'Erfolg' });
+    form.refId = '';
+    await load();
+  } catch (err) {
+    toast.add({ color: 'error', description: (err as Error).message, title: 'Fehler' });
+  } finally {
+    saving.value = false;
+  }
+}
+
+async function remove(pref: LtAiConnectionPreference): Promise<void> {
+  if (!pref.id) {
+    return;
+  }
+  try {
+    await admin.deletePreference(pref.id);
+    toast.add({ color: 'success', description: 'Präferenz gelöscht.', title: 'Erfolg' });
+    await load();
+  } catch (err) {
+    toast.add({ color: 'error', description: (err as Error).message, title: 'Fehler' });
+  }
+}
+
+function connectionName(id: string): string {
+  return connections.value.find((c) => c.id === id)?.name || id;
+}
+</script>
+
+<template>
+  <div class="mx-auto max-w-4xl space-y-6">
+    <div>
+      <h1 class="text-2xl font-bold">KI-Verbindungs-Präferenzen</h1>
+      <p class="text-muted">Standard-Verbindung pro Tenant/Nutzer; „erzwungen" überschreibt die Nutzerwahl.</p>
+    </div>
+
+    <UCard>
+      <template #header><h2 class="font-semibold">Neue Präferenz</h2></template>
+      <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <UFormField label="Bereich"><USelectMenu v-model="form.scope" :items="scopeItems" value-key="value" /></UFormField>
+        <UFormField label="Verbindung"><USelectMenu v-model="form.connectionId" :items="connectionItems" value-key="value" placeholder="Verbindung wählen" /></UFormField>
+        <UFormField label="Referenz-ID (Tenant/Nutzer)" class="sm:col-span-2"><UInput v-model="form.refId" placeholder="ObjectId" /></UFormField>
+        <UCheckbox v-if="form.scope === 'tenant'" v-model="form.enforced" label="Erzwingen (Nutzer können nicht abweichen)" />
+      </div>
+      <template #footer><UButton icon="i-lucide-plus" :loading="saving" @click="save"> Präferenz speichern </UButton></template>
+    </UCard>
+
+    <UCard>
+      <template #header><h2 class="font-semibold">Bestehende Präferenzen</h2></template>
+      <div v-if="loading" class="py-8 text-center text-muted"><UIcon name="i-lucide-loader-circle" class="size-6 animate-spin" /></div>
+      <p v-else-if="!preferences.length" class="py-8 text-center text-muted">Keine Präferenzen konfiguriert.</p>
+      <div v-else class="divide-y">
+        <div v-for="pref in preferences" :key="pref.id" class="flex items-center justify-between py-3">
+          <div>
+            <p class="font-medium">
+              {{ pref.scope === 'user' ? 'Nutzer' : 'Tenant' }} · {{ pref.refId }}
+              <UBadge v-if="pref.enforced" size="sm" color="warning" variant="subtle">erzwungen</UBadge>
+            </p>
+            <p class="text-xs text-muted">→ {{ connectionName(pref.connectionId) }}</p>
+          </div>
+          <UButton size="sm" variant="ghost" color="error" icon="i-lucide-trash" @click="remove(pref)" />
+        </div>
+      </div>
+    </UCard>
+  </div>
+</template>

--- a/nuxt-base-template/app/pages/app/admin/ai/prompt-hints.vue
+++ b/nuxt-base-template/app/pages/app/admin/ai/prompt-hints.vue
@@ -1,0 +1,171 @@
+<script setup lang="ts">
+// ============================================================================
+// Admin: learned AI prompt hints — review/approve/reject the governed
+// self-improvement loop. Only approved + enabled hints reach the prompt; hints
+// only ever ADD guidance and can never relax the backend-enforced security core.
+// ============================================================================
+import type { LtAiPromptHint, LtAiPromptHintInput } from '@lenne.tech/nuxt-extensions';
+
+useHead({ title: 'KI-Lern-Hinweise' });
+
+const admin = useLtAiAdmin();
+const toast = useToast();
+
+const hints = ref<LtAiPromptHint[]>([]);
+const loading = ref(false);
+const saving = ref(false);
+const showCreate = ref(false);
+
+const form = reactive<LtAiPromptHintInput>({ content: '', scope: '', trigger: 'manual' });
+
+const statusColor: Record<string, 'error' | 'neutral' | 'success' | 'warning'> = {
+  approved: 'success',
+  rejected: 'error',
+  suggested: 'warning',
+};
+
+const suggested = computed(() => hints.value.filter((h) => (h.status || 'suggested') === 'suggested'));
+const reviewed = computed(() => hints.value.filter((h) => (h.status || 'suggested') !== 'suggested'));
+
+onMounted(load);
+
+async function load(): Promise<void> {
+  loading.value = true;
+  try {
+    hints.value = await admin.listPromptHints();
+  } catch (err) {
+    toast.add({ color: 'error', description: (err as Error).message, title: 'Fehler' });
+  } finally {
+    loading.value = false;
+  }
+}
+
+async function setStatus(hint: LtAiPromptHint, status: 'approved' | 'rejected' | 'suggested'): Promise<void> {
+  try {
+    await admin.updatePromptHint(hint.id, { status });
+    toast.add({ color: 'success', description: `Hinweis auf "${status}" gesetzt.`, title: 'Erfolg' });
+    await load();
+  } catch (err) {
+    toast.add({ color: 'error', description: (err as Error).message, title: 'Fehler' });
+  }
+}
+
+async function toggleEnabled(hint: LtAiPromptHint): Promise<void> {
+  try {
+    await admin.updatePromptHint(hint.id, { enabled: hint.enabled === false });
+    await load();
+  } catch (err) {
+    toast.add({ color: 'error', description: (err as Error).message, title: 'Fehler' });
+  }
+}
+
+async function remove(hint: LtAiPromptHint): Promise<void> {
+  try {
+    await admin.deletePromptHint(hint.id);
+    toast.add({ color: 'success', description: 'Hinweis gelöscht.', title: 'Erfolg' });
+    await load();
+  } catch (err) {
+    toast.add({ color: 'error', description: (err as Error).message, title: 'Fehler' });
+  }
+}
+
+async function create(): Promise<void> {
+  if (!form.content?.trim()) {
+    toast.add({ color: 'error', description: 'Bitte einen Hinweistext angeben.', title: 'Fehler' });
+    return;
+  }
+  saving.value = true;
+  try {
+    await admin.createPromptHint({ ...form, scope: form.scope?.trim() || undefined, status: 'approved' });
+    toast.add({ color: 'success', description: 'Hinweis angelegt und freigegeben.', title: 'Erfolg' });
+    form.content = '';
+    form.scope = '';
+    showCreate.value = false;
+    await load();
+  } catch (err) {
+    toast.add({ color: 'error', description: (err as Error).message, title: 'Fehler' });
+  } finally {
+    saving.value = false;
+  }
+}
+</script>
+
+<template>
+  <div class="mx-auto max-w-4xl space-y-6">
+    <div class="flex items-start justify-between gap-3">
+      <div>
+        <h1 class="text-2xl font-bold">KI-Lern-Hinweise</h1>
+        <p class="text-muted">
+          Aus wiederkehrenden Fehlern automatisch abgeleitete Hinweise. Nur <strong>freigegebene</strong> und aktive Hinweise fließen in den Prompt ein. Hinweise ergänzen nur
+          Anleitung — sie können das Rechtemanagement nie aufweichen (das wird serverseitig unabhängig erzwungen).
+        </p>
+      </div>
+      <UButton icon="i-lucide-plus" variant="soft" @click="showCreate = !showCreate"> Manuell </UButton>
+    </div>
+
+    <UCard v-if="showCreate">
+      <template #header><h2 class="font-semibold">Manuellen Hinweis anlegen</h2></template>
+      <div class="grid grid-cols-1 gap-3">
+        <UFormField label="Bereich (scope)" help="z. B. ein Tool-Name; leer = global">
+          <UInput v-model="form.scope" placeholder="global" />
+        </UFormField>
+        <UFormField label="Hinweistext">
+          <UTextarea v-model="form.content" :rows="3" placeholder="Anleitung, die dem Modell hinzugefügt wird" />
+        </UFormField>
+      </div>
+      <template #footer>
+        <UButton icon="i-lucide-plus" :loading="saving" @click="create"> Anlegen & freigeben </UButton>
+      </template>
+    </UCard>
+
+    <UCard>
+      <template #header>
+        <h2 class="font-semibold">
+          Zu prüfen <UBadge v-if="suggested.length" size="xs" color="warning">{{ suggested.length }}</UBadge>
+        </h2>
+      </template>
+      <div v-if="loading" class="py-8 text-center text-muted"><UIcon name="i-lucide-loader-circle" class="size-6 animate-spin" /></div>
+      <p v-else-if="!suggested.length" class="py-8 text-center text-muted">Keine offenen Vorschläge.</p>
+      <div v-else class="divide-y">
+        <div v-for="hint in suggested" :key="hint.id" class="py-3">
+          <div class="flex flex-wrap items-center gap-2">
+            <UBadge size="xs" :color="statusColor[hint.status || 'suggested']" variant="subtle">{{ hint.status || 'suggested' }}</UBadge>
+            <UBadge size="xs" color="neutral" variant="subtle">{{ hint.trigger || 'manual' }}</UBadge>
+            <UBadge v-if="hint.scope" size="xs" color="info" variant="subtle">{{ hint.scope }}</UBadge>
+            <span class="text-xs text-muted">{{ hint.occurrences ?? 1 }}× beobachtet</span>
+          </div>
+          <p class="mt-1 text-sm">{{ hint.content }}</p>
+          <div class="mt-2 flex gap-2">
+            <UButton size="sm" color="success" icon="i-lucide-check" @click="setStatus(hint, 'approved')"> Freigeben </UButton>
+            <UButton size="sm" variant="ghost" color="error" icon="i-lucide-x" @click="setStatus(hint, 'rejected')"> Ablehnen </UButton>
+            <UButton size="sm" variant="ghost" icon="i-lucide-trash" @click="remove(hint)" />
+          </div>
+        </div>
+      </div>
+    </UCard>
+
+    <UCard>
+      <template #header><h2 class="font-semibold">Geprüfte Hinweise</h2></template>
+      <p v-if="!reviewed.length" class="py-8 text-center text-muted">Noch keine geprüften Hinweise.</p>
+      <div v-else class="divide-y">
+        <div v-for="hint in reviewed" :key="hint.id" class="flex items-start justify-between gap-3 py-3">
+          <div class="min-w-0">
+            <div class="flex flex-wrap items-center gap-2">
+              <UBadge size="xs" :color="statusColor[hint.status || 'suggested']" variant="subtle">{{ hint.status }}</UBadge>
+              <UBadge size="xs" color="neutral" variant="subtle">{{ hint.trigger || 'manual' }}</UBadge>
+              <UBadge v-if="hint.scope" size="xs" color="info" variant="subtle">{{ hint.scope }}</UBadge>
+              <UBadge v-if="hint.enabled === false" size="xs" color="warning" variant="subtle">inaktiv</UBadge>
+            </div>
+            <p class="mt-1 text-sm">{{ hint.content }}</p>
+          </div>
+          <div class="flex shrink-0 items-center gap-1">
+            <USwitch :model-value="hint.enabled !== false" size="sm" @update:model-value="toggleEnabled(hint)" />
+            <UButton v-if="hint.status !== 'approved'" size="sm" variant="ghost" color="success" icon="i-lucide-check" @click="setStatus(hint, 'approved')" />
+            <UButton v-if="hint.status !== 'rejected'" size="sm" variant="ghost" color="error" icon="i-lucide-x" @click="setStatus(hint, 'rejected')" />
+            <UButton size="sm" variant="ghost" icon="i-lucide-trash" @click="remove(hint)" />
+          </div>
+        </div>
+      </div>
+    </UCard>
+  </div>
+</template>

--- a/nuxt-base-template/app/pages/app/admin/ai/prompt-hints.vue
+++ b/nuxt-base-template/app/pages/app/admin/ai/prompt-hints.vue
@@ -7,6 +7,7 @@
 import type { LtAiPromptHint, LtAiPromptHintInput } from '@lenne.tech/nuxt-extensions';
 
 useHead({ title: 'KI-Lern-Hinweise' });
+definePageMeta({ ssr: false });
 
 const admin = useLtAiAdmin();
 const toast = useToast();

--- a/nuxt-base-template/app/pages/app/admin/ai/prompt-templates.vue
+++ b/nuxt-base-template/app/pages/app/admin/ai/prompt-templates.vue
@@ -1,0 +1,187 @@
+<script setup lang="ts">
+// ============================================================================
+// Admin: AI prompt templates — edit the building blocks of the system prompt.
+// The backend ships built-in defaults for every key; a row here OVERRIDES the
+// default for its key (optionally scoped by locale/capability).
+// ============================================================================
+import type { LtAiPromptTemplate, LtAiPromptTemplateInput } from '@lenne.tech/nuxt-extensions';
+
+useHead({ title: 'KI-Prompt-Vorlagen' });
+
+const admin = useLtAiAdmin();
+const toast = useToast();
+
+const templates = ref<LtAiPromptTemplate[]>([]);
+const loading = ref(false);
+const saving = ref(false);
+const editId = ref<null | string>(null);
+
+const capabilityItems = [
+  { label: 'Alle Modi', value: 'all' },
+  { label: 'Native Tools', value: 'native' },
+  { label: 'Emulierte Tools', value: 'emulated' },
+];
+
+function emptyForm(): LtAiPromptTemplateInput {
+  return { capability: 'all', content: '', description: '', enabled: true, key: '', locale: '', order: 100 };
+}
+
+const form = reactive<LtAiPromptTemplateInput>(emptyForm());
+
+onMounted(load);
+
+async function load(): Promise<void> {
+  loading.value = true;
+  try {
+    templates.value = await admin.listPromptTemplates();
+  } catch (err) {
+    toast.add({ color: 'error', description: (err as Error).message, title: 'Fehler' });
+  } finally {
+    loading.value = false;
+  }
+}
+
+function reset(): void {
+  editId.value = null;
+  Object.assign(form, emptyForm());
+}
+
+function edit(template: LtAiPromptTemplate): void {
+  editId.value = template.id;
+  Object.assign(form, {
+    capability: template.capability || 'all',
+    content: template.content || '',
+    description: template.description || '',
+    enabled: template.enabled !== false,
+    key: template.key || '',
+    locale: template.locale || '',
+    order: template.order ?? 100,
+  });
+}
+
+async function save(): Promise<void> {
+  if (!form.key?.trim()) {
+    toast.add({ color: 'error', description: 'Bitte einen Slot (key) angeben.', title: 'Fehler' });
+    return;
+  }
+  if (!form.content?.trim()) {
+    toast.add({ color: 'error', description: 'Bitte einen Inhalt angeben.', title: 'Fehler' });
+    return;
+  }
+  saving.value = true;
+  try {
+    const payload: LtAiPromptTemplateInput = { ...form, locale: form.locale?.trim() || undefined };
+    if (editId.value) {
+      await admin.updatePromptTemplate(editId.value, payload);
+      toast.add({ color: 'success', description: 'Vorlage aktualisiert.', title: 'Erfolg' });
+    } else {
+      await admin.createPromptTemplate(payload);
+      toast.add({ color: 'success', description: 'Vorlage angelegt.', title: 'Erfolg' });
+    }
+    reset();
+    await load();
+  } catch (err) {
+    toast.add({ color: 'error', description: (err as Error).message, title: 'Fehler' });
+  } finally {
+    saving.value = false;
+  }
+}
+
+async function remove(template: LtAiPromptTemplate): Promise<void> {
+  try {
+    await admin.deletePromptTemplate(template.id);
+    toast.add({ color: 'success', description: 'Vorlage gelöscht.', title: 'Erfolg' });
+    if (editId.value === template.id) {
+      reset();
+    }
+    await load();
+  } catch (err) {
+    toast.add({ color: 'error', description: (err as Error).message, title: 'Fehler' });
+  }
+}
+
+async function toggleEnabled(template: LtAiPromptTemplate): Promise<void> {
+  try {
+    await admin.updatePromptTemplate(template.id, { enabled: template.enabled === false });
+    await load();
+  } catch (err) {
+    toast.add({ color: 'error', description: (err as Error).message, title: 'Fehler' });
+  }
+}
+</script>
+
+<template>
+  <div class="mx-auto max-w-4xl space-y-6">
+    <div>
+      <h1 class="text-2xl font-bold">KI-Prompt-Vorlagen</h1>
+      <p class="text-muted">
+        Bausteine des System-Prompts. Das Backend liefert für jeden Slot sinnvolle Standards — ein Eintrag hier
+        <strong>überschreibt</strong> den Standard für seinen Slot (optional je Sprache/Modus). Platzhalter wie <code>{{ '{{roles}}' }}</code>, <code>{{ '{{tools}}' }}</code>,
+        <code>{{ '{{toolCatalog}}' }}</code> oder <code>{{ '{{documentation}}' }}</code> werden zur Laufzeit ersetzt.
+      </p>
+    </div>
+
+    <UCard>
+      <template #header>
+        <h2 class="font-semibold">{{ editId ? 'Vorlage bearbeiten' : 'Neue Vorlage' }}</h2>
+      </template>
+      <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <UFormField label="Slot (key)" help="z. B. base, permissions, anti_hallucination">
+          <UInput v-model="form.key" placeholder="base" :disabled="!!editId" />
+        </UFormField>
+        <UFormField label="Modus (capability)">
+          <USelectMenu v-model="form.capability" :items="capabilityItems" value-key="value" />
+        </UFormField>
+        <UFormField label="Sprache (locale)" help="leer = alle Sprachen">
+          <UInput v-model="form.locale" placeholder="de" />
+        </UFormField>
+        <UFormField label="Reihenfolge (order)">
+          <UInput v-model.number="form.order" type="number" placeholder="100" />
+        </UFormField>
+        <UFormField label="Beschreibung" class="sm:col-span-2">
+          <UInput v-model="form.description" placeholder="Wofür ist dieser Baustein?" />
+        </UFormField>
+        <UFormField label="Inhalt" class="sm:col-span-2">
+          <UTextarea v-model="form.content" :rows="5" placeholder="Fragment-Text (unterstützt {{platzhalter}})" />
+        </UFormField>
+        <UFormField label="Aktiv">
+          <USwitch v-model="form.enabled" />
+        </UFormField>
+      </div>
+      <template #footer>
+        <div class="flex gap-2">
+          <UButton :icon="editId ? 'i-lucide-save' : 'i-lucide-plus'" :loading="saving" @click="save">
+            {{ editId ? 'Speichern' : 'Vorlage anlegen' }}
+          </UButton>
+          <UButton v-if="editId" variant="ghost" icon="i-lucide-x" @click="reset"> Abbrechen </UButton>
+        </div>
+      </template>
+    </UCard>
+
+    <UCard>
+      <template #header><h2 class="font-semibold">Bestehende Vorlagen</h2></template>
+      <div v-if="loading" class="py-8 text-center text-muted"><UIcon name="i-lucide-loader-circle" class="size-6 animate-spin" /></div>
+      <p v-else-if="!templates.length" class="py-8 text-center text-muted">Keine eigenen Vorlagen — es gelten die eingebauten Standards.</p>
+      <div v-else class="divide-y">
+        <div v-for="template in templates" :key="template.id" class="flex items-start justify-between gap-3 py-3">
+          <div class="min-w-0">
+            <p class="flex flex-wrap items-center gap-2 font-medium">
+              <span>{{ template.key }}</span>
+              <UBadge size="xs" color="neutral" variant="subtle">{{ template.capability || 'all' }}</UBadge>
+              <UBadge v-if="template.locale" size="xs" color="info" variant="subtle">{{ template.locale }}</UBadge>
+              <UBadge size="xs" variant="subtle">#{{ template.order ?? 100 }}</UBadge>
+              <UBadge v-if="template.enabled === false" size="xs" color="warning" variant="subtle">inaktiv</UBadge>
+            </p>
+            <p v-if="template.description" class="text-xs text-muted">{{ template.description }}</p>
+            <p class="mt-1 line-clamp-2 text-xs text-muted">{{ template.content }}</p>
+          </div>
+          <div class="flex shrink-0 items-center gap-1">
+            <USwitch :model-value="template.enabled !== false" size="sm" @update:model-value="toggleEnabled(template)" />
+            <UButton size="sm" variant="ghost" icon="i-lucide-pencil" @click="edit(template)" />
+            <UButton size="sm" variant="ghost" color="error" icon="i-lucide-trash" @click="remove(template)" />
+          </div>
+        </div>
+      </div>
+    </UCard>
+  </div>
+</template>

--- a/nuxt-base-template/app/pages/app/admin/ai/prompt-templates.vue
+++ b/nuxt-base-template/app/pages/app/admin/ai/prompt-templates.vue
@@ -116,8 +116,9 @@ async function toggleEnabled(template: LtAiPromptTemplate): Promise<void> {
       <h1 class="text-2xl font-bold">KI-Prompt-Vorlagen</h1>
       <p class="text-muted">
         Bausteine des System-Prompts. Das Backend liefert für jeden Slot sinnvolle Standards — ein Eintrag hier
-        <strong>überschreibt</strong> den Standard für seinen Slot (optional je Sprache/Modus). Platzhalter wie <code>{{ '{{roles}}' }}</code>, <code>{{ '{{tools}}' }}</code>,
-        <code>{{ '{{toolCatalog}}' }}</code> oder <code>{{ '{{documentation}}' }}</code> werden zur Laufzeit ersetzt.
+        <strong>überschreibt</strong> den Standard für seinen Slot (optional je Sprache/Modus). Platzhalter wie <code>&#123;&#123;roles&#125;&#125;</code>,
+        <code>&#123;&#123;tools&#125;&#125;</code>, <code>&#123;&#123;toolCatalog&#125;&#125;</code> oder <code>&#123;&#123;documentation&#125;&#125;</code> werden zur Laufzeit
+        ersetzt.
       </p>
     </div>
 
@@ -142,7 +143,7 @@ async function toggleEnabled(template: LtAiPromptTemplate): Promise<void> {
           <UInput v-model="form.description" placeholder="Wofür ist dieser Baustein?" />
         </UFormField>
         <UFormField label="Inhalt" class="sm:col-span-2">
-          <UTextarea v-model="form.content" :rows="5" placeholder="Fragment-Text (unterstützt {{platzhalter}})" />
+          <UTextarea v-model="form.content" :rows="5" placeholder="Fragment-Text (Platzhalter in doppelten geschweiften Klammern)" />
         </UFormField>
         <UFormField label="Aktiv">
           <USwitch v-model="form.enabled" />

--- a/nuxt-base-template/app/pages/app/admin/ai/slots.vue
+++ b/nuxt-base-template/app/pages/app/admin/ai/slots.vue
@@ -9,6 +9,7 @@
 import type { LtAiEffectiveSlot, LtAiSlotInput } from '@lenne.tech/nuxt-extensions';
 
 useHead({ title: 'KI-Slots' });
+definePageMeta({ ssr: false });
 
 const admin = useLtAiAdmin();
 const toast = useToast();

--- a/nuxt-base-template/app/pages/app/admin/ai/slots.vue
+++ b/nuxt-base-template/app/pages/app/admin/ai/slots.vue
@@ -4,14 +4,14 @@
 // The backend ships built-in defaults for every key; a row here OVERRIDES the
 // default for its key (optionally scoped by locale/capability).
 // ============================================================================
-import type { LtAiPromptTemplate, LtAiPromptTemplateInput } from '@lenne.tech/nuxt-extensions';
+import type { LtAiSlot, LtAiSlotInput } from '@lenne.tech/nuxt-extensions';
 
-useHead({ title: 'KI-Prompt-Vorlagen' });
+useHead({ title: 'KI-Slots' });
 
 const admin = useLtAiAdmin();
 const toast = useToast();
 
-const templates = ref<LtAiPromptTemplate[]>([]);
+const templates = ref<LtAiSlot[]>([]);
 const loading = ref(false);
 const saving = ref(false);
 const editId = ref<null | string>(null);
@@ -22,18 +22,18 @@ const capabilityItems = [
   { label: 'Emulierte Tools', value: 'emulated' },
 ];
 
-function emptyForm(): LtAiPromptTemplateInput {
+function emptyForm(): LtAiSlotInput {
   return { capability: 'all', content: '', description: '', enabled: true, key: '', locale: '', order: 100 };
 }
 
-const form = reactive<LtAiPromptTemplateInput>(emptyForm());
+const form = reactive<LtAiSlotInput>(emptyForm());
 
 onMounted(load);
 
 async function load(): Promise<void> {
   loading.value = true;
   try {
-    templates.value = await admin.listPromptTemplates();
+    templates.value = await admin.listSlots();
   } catch (err) {
     toast.add({ color: 'error', description: (err as Error).message, title: 'Fehler' });
   } finally {
@@ -46,7 +46,7 @@ function reset(): void {
   Object.assign(form, emptyForm());
 }
 
-function edit(template: LtAiPromptTemplate): void {
+function edit(template: LtAiSlot): void {
   editId.value = template.id;
   Object.assign(form, {
     capability: template.capability || 'all',
@@ -70,12 +70,12 @@ async function save(): Promise<void> {
   }
   saving.value = true;
   try {
-    const payload: LtAiPromptTemplateInput = { ...form, locale: form.locale?.trim() || undefined };
+    const payload: LtAiSlotInput = { ...form, locale: form.locale?.trim() || undefined };
     if (editId.value) {
-      await admin.updatePromptTemplate(editId.value, payload);
+      await admin.updateSlot(editId.value, payload);
       toast.add({ color: 'success', description: 'Vorlage aktualisiert.', title: 'Erfolg' });
     } else {
-      await admin.createPromptTemplate(payload);
+      await admin.createSlot(payload);
       toast.add({ color: 'success', description: 'Vorlage angelegt.', title: 'Erfolg' });
     }
     reset();
@@ -87,9 +87,9 @@ async function save(): Promise<void> {
   }
 }
 
-async function remove(template: LtAiPromptTemplate): Promise<void> {
+async function remove(template: LtAiSlot): Promise<void> {
   try {
-    await admin.deletePromptTemplate(template.id);
+    await admin.deleteSlot(template.id);
     toast.add({ color: 'success', description: 'Vorlage gelöscht.', title: 'Erfolg' });
     if (editId.value === template.id) {
       reset();
@@ -100,9 +100,9 @@ async function remove(template: LtAiPromptTemplate): Promise<void> {
   }
 }
 
-async function toggleEnabled(template: LtAiPromptTemplate): Promise<void> {
+async function toggleEnabled(template: LtAiSlot): Promise<void> {
   try {
-    await admin.updatePromptTemplate(template.id, { enabled: template.enabled === false });
+    await admin.updateSlot(template.id, { enabled: template.enabled === false });
     await load();
   } catch (err) {
     toast.add({ color: 'error', description: (err as Error).message, title: 'Fehler' });
@@ -113,7 +113,7 @@ async function toggleEnabled(template: LtAiPromptTemplate): Promise<void> {
 <template>
   <div class="mx-auto max-w-4xl space-y-6">
     <div>
-      <h1 class="text-2xl font-bold">KI-Prompt-Vorlagen</h1>
+      <h1 class="text-2xl font-bold">KI-Slots</h1>
       <p class="text-muted">
         Bausteine des System-Prompts. Das Backend liefert für jeden Slot sinnvolle Standards — ein Eintrag hier
         <strong>überschreibt</strong> den Standard für seinen Slot (optional je Sprache/Modus). Platzhalter wie <code>&#123;&#123;roles&#125;&#125;</code>,

--- a/nuxt-base-template/app/pages/app/admin/ai/slots.vue
+++ b/nuxt-base-template/app/pages/app/admin/ai/slots.vue
@@ -1,20 +1,22 @@
 <script setup lang="ts">
 // ============================================================================
-// Admin: AI prompt templates — edit the building blocks of the system prompt.
-// The backend ships built-in defaults for every key; a row here OVERRIDES the
-// default for its key (optionally scoped by locale/capability).
+// Admin: AI Slots — tenant-scoped overrides of the system-prompt building
+// blocks. Framework defaults appear as virtual rows; "Bearbeiten" creates an
+// override, "Zurücksetzen" deletes it, "Deaktivieren" on a system slot
+// soft-deletes it for the tenant (disabled override). "Löschen" on a custom
+// tenant slot is a real, non-recoverable delete.
 // ============================================================================
-import type { LtAiSlot, LtAiSlotInput } from '@lenne.tech/nuxt-extensions';
+import type { LtAiEffectiveSlot, LtAiSlotInput } from '@lenne.tech/nuxt-extensions';
 
 useHead({ title: 'KI-Slots' });
 
 const admin = useLtAiAdmin();
 const toast = useToast();
 
-const templates = ref<LtAiSlot[]>([]);
+const slots = ref<LtAiEffectiveSlot[]>([]);
 const loading = ref(false);
 const saving = ref(false);
-const editId = ref<null | string>(null);
+const editing = ref<LtAiEffectiveSlot | null>(null);
 
 const capabilityItems = [
   { label: 'Alle Modi', value: 'all' },
@@ -33,7 +35,7 @@ onMounted(load);
 async function load(): Promise<void> {
   loading.value = true;
   try {
-    templates.value = await admin.listSlots();
+    slots.value = await admin.listEffectiveSlots();
   } catch (err) {
     toast.add({ color: 'error', description: (err as Error).message, title: 'Fehler' });
   } finally {
@@ -41,44 +43,46 @@ async function load(): Promise<void> {
   }
 }
 
-function reset(): void {
-  editId.value = null;
+function startNew(): void {
+  editing.value = null;
   Object.assign(form, emptyForm());
 }
 
-function edit(template: LtAiSlot): void {
-  editId.value = template.id;
+function startEdit(s: LtAiEffectiveSlot): void {
+  editing.value = s;
   Object.assign(form, {
-    capability: template.capability || 'all',
-    content: template.content || '',
-    description: template.description || '',
-    enabled: template.enabled !== false,
-    key: template.key || '',
-    locale: template.locale || '',
-    order: template.order ?? 100,
+    capability: s.capability || 'all',
+    content: s.content || '',
+    description: s.description || '',
+    enabled: s.enabled,
+    key: s.key,
+    locale: s.locale || '',
+    order: s.order ?? 100,
   });
 }
 
 async function save(): Promise<void> {
   if (!form.key?.trim()) {
-    toast.add({ color: 'error', description: 'Bitte einen Slot (key) angeben.', title: 'Fehler' });
+    toast.add({ color: 'error', description: 'Slot-Key fehlt.', title: 'Fehler' });
     return;
   }
   if (!form.content?.trim()) {
-    toast.add({ color: 'error', description: 'Bitte einen Inhalt angeben.', title: 'Fehler' });
+    toast.add({ color: 'error', description: 'Inhalt darf nicht leer sein.', title: 'Fehler' });
     return;
   }
   saving.value = true;
   try {
     const payload: LtAiSlotInput = { ...form, locale: form.locale?.trim() || undefined };
-    if (editId.value) {
-      await admin.updateSlot(editId.value, payload);
-      toast.add({ color: 'success', description: 'Vorlage aktualisiert.', title: 'Erfolg' });
+    if (editing.value?.id && (editing.value.isOverride || (!editing.value.isSystem && !editing.value.isOverride))) {
+      // Update an existing override or custom slot.
+      await admin.updateSlot(editing.value.id, payload);
+      toast.add({ color: 'success', description: 'Slot aktualisiert.', title: 'Erfolg' });
     } else {
+      // Either: overriding a system default for the first time, OR creating a new custom slot.
       await admin.createSlot(payload);
-      toast.add({ color: 'success', description: 'Vorlage angelegt.', title: 'Erfolg' });
+      toast.add({ color: 'success', description: editing.value?.isSystem ? 'Override angelegt.' : 'Slot angelegt.', title: 'Erfolg' });
     }
-    reset();
+    startNew();
     await load();
   } catch (err) {
     toast.add({ color: 'error', description: (err as Error).message, title: 'Fehler' });
@@ -87,102 +91,168 @@ async function save(): Promise<void> {
   }
 }
 
-async function remove(template: LtAiSlot): Promise<void> {
+async function reset(s: LtAiEffectiveSlot): Promise<void> {
+  if (!s.id) return;
   try {
-    await admin.deleteSlot(template.id);
-    toast.add({ color: 'success', description: 'Vorlage gelöscht.', title: 'Erfolg' });
-    if (editId.value === template.id) {
-      reset();
-    }
+    await admin.resetSlot(s.id);
+    toast.add({ color: 'success', description: 'Auf System-Standard zurückgesetzt.', title: 'Erfolg' });
+    if (editing.value?.id === s.id) startNew();
     await load();
   } catch (err) {
     toast.add({ color: 'error', description: (err as Error).message, title: 'Fehler' });
   }
 }
 
-async function toggleEnabled(template: LtAiSlot): Promise<void> {
+async function remove(s: LtAiEffectiveSlot): Promise<void> {
+  if (!s.id) return;
   try {
-    await admin.updateSlot(template.id, { enabled: template.enabled === false });
+    await admin.deleteSlot(s.id);
+    toast.add({ color: 'success', description: 'Slot gelöscht.', title: 'Erfolg' });
+    if (editing.value?.id === s.id) startNew();
     await load();
   } catch (err) {
     toast.add({ color: 'error', description: (err as Error).message, title: 'Fehler' });
   }
+}
+
+async function softDeleteSystem(s: LtAiEffectiveSlot): Promise<void> {
+  // System default → create a disabled override (hides it for this tenant).
+  try {
+    await admin.createSlot({ content: s.content, enabled: false, key: s.key, order: s.order });
+    toast.add({ color: 'warning', description: `"${s.key}" ist für diesen Tenant deaktiviert.`, title: 'Deaktiviert' });
+    await load();
+  } catch (err) {
+    toast.add({ color: 'error', description: (err as Error).message, title: 'Fehler' });
+  }
+}
+
+const systemAndOverrides = computed(() => slots.value.filter((s) => s.isSystem || s.isOverride));
+const customs = computed(() => slots.value.filter((s) => !s.isSystem && !s.isOverride));
+
+function formTitle(): string {
+  if (!editing.value) return 'Neuen eigenen Slot anlegen';
+  if (editing.value.isSystem) return `System-Slot überschreiben: ${editing.value.key}`;
+  if (editing.value.isOverride) return `Override bearbeiten: ${editing.value.key}`;
+  return `Eigenen Slot bearbeiten: ${editing.value.key}`;
 }
 </script>
 
 <template>
-  <div class="mx-auto max-w-4xl space-y-6">
-    <div>
+  <div class="mx-auto max-w-7xl">
+    <div class="mb-6">
       <h1 class="text-2xl font-bold">KI-Slots</h1>
       <p class="text-muted">
-        Bausteine des System-Prompts. Das Backend liefert für jeden Slot sinnvolle Standards — ein Eintrag hier
-        <strong>überschreibt</strong> den Standard für seinen Slot (optional je Sprache/Modus). Platzhalter wie <code>&#123;&#123;roles&#125;&#125;</code>,
-        <code>&#123;&#123;tools&#125;&#125;</code>, <code>&#123;&#123;toolCatalog&#125;&#125;</code> oder <code>&#123;&#123;documentation&#125;&#125;</code> werden zur Laufzeit
-        ersetzt.
+        Bausteine des System-Prompts. Das Framework liefert für jeden Slot sinnvolle Standards — ein Tenant-Eintrag hier
+        <strong>überschreibt</strong> ihn nur für deinen Tenant. Eigene Slots ergänzen den Prompt um zusätzliche Anweisungen. Beim Editieren rechts die verfügbaren Platzhalter
+        beachten.
       </p>
     </div>
 
-    <UCard>
-      <template #header>
-        <h2 class="font-semibold">{{ editId ? 'Vorlage bearbeiten' : 'Neue Vorlage' }}</h2>
-      </template>
-      <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
-        <UFormField label="Slot (key)" help="z. B. base, permissions, anti_hallucination">
-          <UInput v-model="form.key" placeholder="base" :disabled="!!editId" />
-        </UFormField>
-        <UFormField label="Modus (capability)">
-          <USelectMenu v-model="form.capability" :items="capabilityItems" value-key="value" />
-        </UFormField>
-        <UFormField label="Sprache (locale)" help="leer = alle Sprachen">
-          <UInput v-model="form.locale" placeholder="de" />
-        </UFormField>
-        <UFormField label="Reihenfolge (order)">
-          <UInput v-model.number="form.order" type="number" placeholder="100" />
-        </UFormField>
-        <UFormField label="Beschreibung" class="sm:col-span-2">
-          <UInput v-model="form.description" placeholder="Wofür ist dieser Baustein?" />
-        </UFormField>
-        <UFormField label="Inhalt" class="sm:col-span-2">
-          <UTextarea v-model="form.content" :rows="5" placeholder="Fragment-Text (Platzhalter in doppelten geschweiften Klammern)" />
-        </UFormField>
-        <UFormField label="Aktiv">
-          <USwitch v-model="form.enabled" />
-        </UFormField>
-      </div>
-      <template #footer>
-        <div class="flex gap-2">
-          <UButton :icon="editId ? 'i-lucide-save' : 'i-lucide-plus'" :loading="saving" @click="save">
-            {{ editId ? 'Speichern' : 'Vorlage anlegen' }}
-          </UButton>
-          <UButton v-if="editId" variant="ghost" icon="i-lucide-x" @click="reset"> Abbrechen </UButton>
-        </div>
-      </template>
-    </UCard>
+    <div class="grid gap-6 lg:grid-cols-[1fr_320px]">
+      <div class="space-y-6">
+        <!-- Edit form -->
+        <UCard>
+          <template #header>
+            <h2 class="font-semibold">{{ formTitle() }}</h2>
+          </template>
+          <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            <UFormField label="Slot-Key" help="z. B. base, permissions, anti_hallucination, oder ein eigener Name">
+              <UInput v-model="form.key" placeholder="base" :disabled="!!editing && (editing.isSystem || editing.isOverride)" />
+            </UFormField>
+            <UFormField label="Modus (capability)">
+              <USelectMenu v-model="form.capability" :items="capabilityItems" value-key="value" />
+            </UFormField>
+            <UFormField label="Sprache (locale)" help="leer = alle Sprachen">
+              <UInput v-model="form.locale" placeholder="de" />
+            </UFormField>
+            <UFormField label="Reihenfolge">
+              <UInput v-model.number="form.order" type="number" placeholder="100" />
+            </UFormField>
+            <UFormField label="Beschreibung" class="sm:col-span-2">
+              <UInput v-model="form.description" placeholder="Optional — wofür ist dieser Slot?" />
+            </UFormField>
+            <UFormField label="Inhalt" class="sm:col-span-2" help="Platzhalter rechts in der Sidebar einsehen.">
+              <UTextarea v-model="form.content" :rows="6" placeholder="Du bist …" />
+            </UFormField>
+            <UFormField label="Aktiv">
+              <USwitch v-model="form.enabled" />
+            </UFormField>
+          </div>
+          <template #footer>
+            <div class="flex gap-2">
+              <UButton :icon="editing ? 'i-lucide-save' : 'i-lucide-plus'" :loading="saving" @click="save">
+                {{ editing ? 'Speichern' : 'Anlegen' }}
+              </UButton>
+              <UButton v-if="editing" variant="ghost" icon="i-lucide-x" @click="startNew">Abbrechen</UButton>
+            </div>
+          </template>
+        </UCard>
 
-    <UCard>
-      <template #header><h2 class="font-semibold">Bestehende Vorlagen</h2></template>
-      <div v-if="loading" class="py-8 text-center text-muted"><UIcon name="i-lucide-loader-circle" class="size-6 animate-spin" /></div>
-      <p v-else-if="!templates.length" class="py-8 text-center text-muted">Keine eigenen Vorlagen — es gelten die eingebauten Standards.</p>
-      <div v-else class="divide-y">
-        <div v-for="template in templates" :key="template.id" class="flex items-start justify-between gap-3 py-3">
-          <div class="min-w-0">
-            <p class="flex flex-wrap items-center gap-2 font-medium">
-              <span>{{ template.key }}</span>
-              <UBadge size="xs" color="neutral" variant="subtle">{{ template.capability || 'all' }}</UBadge>
-              <UBadge v-if="template.locale" size="xs" color="info" variant="subtle">{{ template.locale }}</UBadge>
-              <UBadge size="xs" variant="subtle">#{{ template.order ?? 100 }}</UBadge>
-              <UBadge v-if="template.enabled === false" size="xs" color="warning" variant="subtle">inaktiv</UBadge>
-            </p>
-            <p v-if="template.description" class="text-xs text-muted">{{ template.description }}</p>
-            <p class="mt-1 line-clamp-2 text-xs text-muted">{{ template.content }}</p>
+        <!-- System defaults + overrides -->
+        <UCard>
+          <template #header><h2 class="font-semibold">System-Slots</h2></template>
+          <div v-if="loading" class="py-8 text-center text-muted">
+            <UIcon name="i-lucide-loader-circle" class="size-6 animate-spin" />
           </div>
-          <div class="flex shrink-0 items-center gap-1">
-            <USwitch :model-value="template.enabled !== false" size="sm" @update:model-value="toggleEnabled(template)" />
-            <UButton size="sm" variant="ghost" icon="i-lucide-pencil" @click="edit(template)" />
-            <UButton size="sm" variant="ghost" color="error" icon="i-lucide-trash" @click="remove(template)" />
+          <div v-else class="divide-y">
+            <div v-for="s in systemAndOverrides" :key="s.key" class="flex items-start justify-between gap-3 py-3">
+              <div class="min-w-0 flex-1">
+                <p class="flex flex-wrap items-center gap-2 font-medium">
+                  <span class="font-mono text-sm">{{ s.key }}</span>
+                  <UBadge size="xs" :color="s.isOverride ? 'warning' : 'success'" variant="subtle">
+                    {{ s.isOverride ? 'Tenant-Override' : 'System-Standard' }}
+                  </UBadge>
+                  <UBadge size="xs" color="neutral" variant="subtle">{{ s.capability || 'all' }}</UBadge>
+                  <UBadge v-if="s.locale" size="xs" color="info" variant="subtle">{{ s.locale }}</UBadge>
+                  <UBadge size="xs" variant="subtle">#{{ s.order }}</UBadge>
+                  <UBadge v-if="!s.enabled" size="xs" color="error" variant="subtle">inaktiv</UBadge>
+                </p>
+                <p v-if="s.description" class="text-xs text-muted">{{ s.description }}</p>
+                <p class="mt-1 line-clamp-2 whitespace-pre-wrap text-xs text-muted">{{ s.content }}</p>
+              </div>
+              <div class="flex shrink-0 items-center gap-1">
+                <UButton size="sm" variant="ghost" icon="i-lucide-pencil" :title="s.isSystem ? 'Override anlegen' : 'Override bearbeiten'" @click="startEdit(s)" />
+                <UButton v-if="s.isOverride" size="sm" variant="ghost" color="warning" icon="i-lucide-rotate-ccw" title="Zurücksetzen auf System-Standard" @click="reset(s)" />
+                <UButton v-if="s.isSystem" size="sm" variant="ghost" color="error" icon="i-lucide-eye-off" title="Für diesen Tenant deaktivieren" @click="softDeleteSystem(s)" />
+              </div>
+            </div>
           </div>
-        </div>
+        </UCard>
+
+        <!-- Custom tenant slots -->
+        <UCard>
+          <template #header><h2 class="font-semibold">Eigene Slots (Tenant)</h2></template>
+          <div v-if="loading" class="py-8 text-center text-muted">
+            <UIcon name="i-lucide-loader-circle" class="size-6 animate-spin" />
+          </div>
+          <p v-else-if="!customs.length" class="py-4 text-center text-sm text-muted">Keine eigenen Slots angelegt.</p>
+          <div v-else class="divide-y">
+            <div v-for="s in customs" :key="s.id" class="flex items-start justify-between gap-3 py-3">
+              <div class="min-w-0 flex-1">
+                <p class="flex flex-wrap items-center gap-2 font-medium">
+                  <span class="font-mono text-sm">{{ s.key }}</span>
+                  <UBadge size="xs" color="primary" variant="subtle">Eigener Slot</UBadge>
+                  <UBadge size="xs" color="neutral" variant="subtle">{{ s.capability || 'all' }}</UBadge>
+                  <UBadge v-if="s.locale" size="xs" color="info" variant="subtle">{{ s.locale }}</UBadge>
+                  <UBadge size="xs" variant="subtle">#{{ s.order }}</UBadge>
+                  <UBadge v-if="!s.enabled" size="xs" color="warning" variant="subtle">inaktiv</UBadge>
+                </p>
+                <p v-if="s.description" class="text-xs text-muted">{{ s.description }}</p>
+                <p class="mt-1 line-clamp-2 whitespace-pre-wrap text-xs text-muted">{{ s.content }}</p>
+              </div>
+              <div class="flex shrink-0 items-center gap-1">
+                <UButton size="sm" variant="ghost" icon="i-lucide-pencil" @click="startEdit(s)" />
+                <UButton size="sm" variant="ghost" color="error" icon="i-lucide-trash" title="Endgültig löschen (nicht wiederherstellbar)" @click="remove(s)" />
+              </div>
+            </div>
+          </div>
+        </UCard>
       </div>
-    </UCard>
+
+      <!-- Placeholder helper sidebar -->
+      <aside class="space-y-4">
+        <AiPlaceholderHint />
+      </aside>
+    </div>
   </div>
 </template>

--- a/nuxt-base-template/app/pages/app/admin/index.vue
+++ b/nuxt-base-template/app/pages/app/admin/index.vue
@@ -9,6 +9,8 @@ const cards = [
   { description: 'Standard-Verbindung pro Tenant/Nutzer', icon: 'i-lucide-list-checks', title: 'KI-Präferenzen', to: '/app/admin/ai/preferences' },
   { description: 'Token-/Anfrage-Limits', icon: 'i-lucide-gauge', title: 'KI-Budgets', to: '/app/admin/ai/budgets' },
   { description: 'Protokoll der Prompt-Läufe', icon: 'i-lucide-scroll-text', title: 'KI-Audit-Log', to: '/app/admin/ai/interactions' },
+  { description: 'Prompt-Bausteine bearbeiten', icon: 'i-lucide-file-pen', title: 'KI-Prompt-Vorlagen', to: '/app/admin/ai/prompt-templates' },
+  { description: 'Gelernte Hinweise prüfen & freigeben', icon: 'i-lucide-graduation-cap', title: 'KI-Lern-Hinweise', to: '/app/admin/ai/prompt-hints' },
 ];
 </script>
 

--- a/nuxt-base-template/app/pages/app/admin/index.vue
+++ b/nuxt-base-template/app/pages/app/admin/index.vue
@@ -1,0 +1,35 @@
+<script setup lang="ts">
+// ============================================================================
+// Admin dashboard — entry point for admin-only areas (/app/admin/*).
+// ============================================================================
+useHead({ title: 'Administration' });
+
+const cards = [
+  { description: 'LLM-Verbindungen verwalten + Fähigkeiten erkennen', icon: 'i-lucide-plug', title: 'KI-Verbindungen', to: '/app/admin/ai/connections' },
+  { description: 'Standard-Verbindung pro Tenant/Nutzer', icon: 'i-lucide-list-checks', title: 'KI-Präferenzen', to: '/app/admin/ai/preferences' },
+  { description: 'Token-/Anfrage-Limits', icon: 'i-lucide-gauge', title: 'KI-Budgets', to: '/app/admin/ai/budgets' },
+  { description: 'Protokoll der Prompt-Läufe', icon: 'i-lucide-scroll-text', title: 'KI-Audit-Log', to: '/app/admin/ai/interactions' },
+];
+</script>
+
+<template>
+  <div class="mx-auto max-w-4xl space-y-6">
+    <div>
+      <h1 class="text-2xl font-bold">Administration</h1>
+      <p class="text-muted">Verwaltungsbereiche für Administratoren.</p>
+    </div>
+    <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+      <ULink v-for="card in cards" :key="card.to" :to="card.to" class="block">
+        <UCard class="h-full transition hover:ring-2 hover:ring-primary">
+          <div class="flex items-start gap-3">
+            <UIcon :name="card.icon" class="size-6 shrink-0 text-primary" />
+            <div>
+              <h2 class="font-semibold">{{ card.title }}</h2>
+              <p class="text-sm text-muted">{{ card.description }}</p>
+            </div>
+          </div>
+        </UCard>
+      </ULink>
+    </div>
+  </div>
+</template>

--- a/nuxt-base-template/app/pages/app/admin/index.vue
+++ b/nuxt-base-template/app/pages/app/admin/index.vue
@@ -9,7 +9,7 @@ const cards = [
   { description: 'Standard-Verbindung pro Tenant/Nutzer', icon: 'i-lucide-list-checks', title: 'KI-Präferenzen', to: '/app/admin/ai/preferences' },
   { description: 'Token-/Anfrage-Limits', icon: 'i-lucide-gauge', title: 'KI-Budgets', to: '/app/admin/ai/budgets' },
   { description: 'Protokoll der Prompt-Läufe', icon: 'i-lucide-scroll-text', title: 'KI-Audit-Log', to: '/app/admin/ai/interactions' },
-  { description: 'Prompt-Bausteine bearbeiten', icon: 'i-lucide-file-pen', title: 'KI-Prompt-Vorlagen', to: '/app/admin/ai/prompt-templates' },
+  { description: 'Prompt-Bausteine bearbeiten', icon: 'i-lucide-file-pen', title: 'KI-Slots', to: '/app/admin/ai/slots' },
   { description: 'Gelernte Hinweise prüfen & freigeben', icon: 'i-lucide-graduation-cap', title: 'KI-Lern-Hinweise', to: '/app/admin/ai/prompt-hints' },
 ];
 </script>

--- a/nuxt-base-template/app/pages/app/ai/index.vue
+++ b/nuxt-base-template/app/pages/app/ai/index.vue
@@ -3,6 +3,9 @@
 // AI assistant chat page (any authenticated user — protected by auth.global).
 // ============================================================================
 useHead({ title: 'KI-Assistent' });
+// Authenticated SPA — data loads client-side via composables; SSR would only
+// emit an empty skeleton and waste server CPU.
+definePageMeta({ ssr: false });
 </script>
 
 <template>

--- a/nuxt-base-template/app/pages/app/ai/index.vue
+++ b/nuxt-base-template/app/pages/app/ai/index.vue
@@ -1,0 +1,16 @@
+<script setup lang="ts">
+// ============================================================================
+// AI assistant chat page (any authenticated user — protected by auth.global).
+// ============================================================================
+useHead({ title: 'KI-Assistent' });
+</script>
+
+<template>
+  <div class="mx-auto flex h-[calc(100vh-12rem)] max-w-3xl flex-col gap-4">
+    <div>
+      <h1 class="text-2xl font-bold">KI-Assistent</h1>
+      <p class="text-muted">Frage den Assistenten — er kann im Backend abgesicherte Aktionen ausführen.</p>
+    </div>
+    <AiChat class="flex-1" />
+  </div>
+</template>

--- a/nuxt-base-template/app/pages/app/index.vue
+++ b/nuxt-base-template/app/pages/app/index.vue
@@ -5,6 +5,15 @@
 const { user, signOut } = useLtAuth();
 
 // ============================================================================
+// Navigation — wrapper because `navigateTo` is auto-imported in <script setup>
+// but not exposed to the template scope (template gets the component's `this`,
+// not the module scope).
+// ============================================================================
+function goTo(path: string): ReturnType<typeof navigateTo> {
+  return navigateTo(path);
+}
+
+// ============================================================================
 // Variables
 // ============================================================================
 const pages = [
@@ -39,7 +48,7 @@ async function handleSignOut(): Promise<void> {
     <div class="mb-8">
       <h2 class="mb-4 text-xl font-semibold">Schnellzugriff</h2>
       <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        <UCard v-for="page in pages" :key="page.to" class="cursor-pointer transition-shadow hover:shadow-lg" @click="navigateTo(page.to)">
+        <UCard v-for="page in pages" :key="page.to" class="cursor-pointer transition-shadow hover:shadow-lg" @click="goTo(page.to)">
           <div class="flex items-start gap-4">
             <div class="rounded-lg bg-primary/10 p-3">
               <UIcon :name="page.icon" class="size-6 text-primary" />

--- a/nuxt-base-template/app/pages/app/settings/ai-prompts.vue
+++ b/nuxt-base-template/app/pages/app/settings/ai-prompts.vue
@@ -1,47 +1,39 @@
 <script setup lang="ts">
 // ============================================================================
-// User-facing AI prompt snippets ("Vorlagen") settings:
-//   - list every snippet visible to the current user (own + tenant + global)
-//   - CRUD for own snippets
+// User-facing AI prompts ("Vorlagen") settings:
+//   - list every prompt visible to the current user (own private + tenant public)
+//   - CRUD for own prompts
 //   - share with the whole tenant (no admin role needed)
-//   - admins additionally see / can author `global` snippets
 //
-// Owner-only mutations are enforced server-side; admins can edit any snippet
-// via the standard admin pipeline.
+// Owner-only mutations are enforced server-side.
 // ============================================================================
-import type { LtAiPromptSnippet, LtAiPromptSnippetInput } from '@lenne.tech/nuxt-extensions';
+import type { LtAiPrompt, LtAiPromptInput } from '@lenne.tech/nuxt-extensions';
 
 useHead({ title: 'KI-Vorlagen' });
 
 const { user } = useLtAuth();
 const toast = useToast();
-const { create, error, load, loading, remove, snippets, update } = useLtAiSnippets();
+const { create, error, load, loading, remove, prompts, update } = useLtAiPrompts();
 
 const isAdmin = computed(() => Array.isArray(user.value?.roles) && user.value!.roles!.includes('admin'));
 const myUserId = computed(() => user.value?.id);
 
-const scopeItems = computed(() => {
-  const items = [
-    { label: 'Nur für mich', value: 'user' },
-    { label: 'Tenant teilen', value: 'tenant' },
-  ];
-  if (isAdmin.value) {
-    items.push({ label: 'Global (alle)', value: 'global' });
-  }
-  return items;
-});
+const scopeItems = [
+  { label: 'Nur für mich (privat)', value: 'user' },
+  { label: 'Mit dem Tenant teilen (öffentlich)', value: 'tenant' },
+];
 
-function emptyForm(): LtAiPromptSnippetInput {
+function emptyForm(): LtAiPromptInput {
   return { content: '', description: '', enabled: true, icon: '', name: '', order: 100, scope: 'user' };
 }
 
-const form = reactive<LtAiPromptSnippetInput>(emptyForm());
+const form = reactive<LtAiPromptInput>(emptyForm());
 const editId = ref<null | string>(null);
 const saving = ref(false);
 
 onMounted(load);
 
-function canMutate(s: LtAiPromptSnippet): boolean {
+function canMutate(s: LtAiPrompt): boolean {
   return isAdmin.value || s.ownerId === myUserId.value;
 }
 
@@ -50,7 +42,7 @@ function reset(): void {
   Object.assign(form, emptyForm());
 }
 
-function edit(s: LtAiPromptSnippet): void {
+function edit(s: LtAiPrompt): void {
   editId.value = s.id;
   Object.assign(form, {
     content: s.content || '',
@@ -74,7 +66,7 @@ async function save(): Promise<void> {
   }
   saving.value = true;
   try {
-    const payload: LtAiPromptSnippetInput = { ...form };
+    const payload: LtAiPromptInput = { ...form };
     if (editId.value) {
       await update(editId.value, payload);
       toast.add({ color: 'success', description: 'Vorlage aktualisiert.', title: 'Erfolg' });
@@ -90,7 +82,7 @@ async function save(): Promise<void> {
   }
 }
 
-async function onDelete(s: LtAiPromptSnippet): Promise<void> {
+async function onDelete(s: LtAiPrompt): Promise<void> {
   try {
     await remove(s.id);
     toast.add({ color: 'success', description: 'Vorlage gelöscht.', title: 'Erfolg' });
@@ -103,9 +95,8 @@ async function onDelete(s: LtAiPromptSnippet): Promise<void> {
 }
 
 const grouped = computed(() => ({
-  user: snippets.value.filter((s) => s.scope === 'user'),
-  tenant: snippets.value.filter((s) => s.scope === 'tenant'),
-  global: snippets.value.filter((s) => s.scope === 'global'),
+  user: prompts.value.filter((s) => s.scope === 'user'),
+  tenant: prompts.value.filter((s) => s.scope === 'tenant'),
 }));
 </script>
 
@@ -114,8 +105,8 @@ const grouped = computed(() => ({
     <div>
       <h1 class="text-2xl font-bold">KI-Vorlagen</h1>
       <p class="text-muted">
-        Schnelle Textbausteine, die du im KI-Chat per Klick einfügen kannst. Sichtbarkeit: <strong>Nur für mich</strong>, <strong>Tenant</strong> (alle Mitglieder deines Tenants)
-        oder <strong>Global</strong> (alle Nutzer — nur Admins).
+        Schnelle Textbausteine, die du im KI-Chat per Klick einfügen kannst. Sichtbarkeit: <strong>Privat</strong> (nur du) oder <strong>Tenant</strong> (alle Mitglieder deines
+        Tenants).
       </p>
     </div>
 
@@ -127,16 +118,16 @@ const grouped = computed(() => ({
       </template>
       <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
         <UFormField label="Name">
-          <UInput v-model="form.name" placeholder="z. B. Kurze freundliche Antwort" data-test="snippet-name" />
+          <UInput v-model="form.name" placeholder="z. B. Kurze freundliche Antwort" data-test="prompt-name" />
         </UFormField>
         <UFormField label="Sichtbarkeit">
-          <USelectMenu v-model="form.scope" :items="scopeItems" value-key="value" data-test="snippet-scope" />
+          <USelectMenu v-model="form.scope" :items="scopeItems" value-key="value" data-test="prompt-scope" />
         </UFormField>
         <UFormField label="Beschreibung" class="sm:col-span-2">
           <UInput v-model="form.description" placeholder="Optional — wofür ist diese Vorlage?" />
         </UFormField>
         <UFormField label="Inhalt" class="sm:col-span-2" help="Wird beim Anklicken in den Chat-Eingabebereich eingefügt.">
-          <UTextarea v-model="form.content" :rows="4" placeholder="Beispiel: Schreibe eine kurze, freundliche Antwort an den Kunden zu …" data-test="snippet-content" />
+          <UTextarea v-model="form.content" :rows="4" placeholder="Beispiel: Schreibe eine kurze, freundliche Antwort an den Kunden zu …" data-test="prompt-content" />
         </UFormField>
         <UFormField label="Icon" help="Lucide-Name (z. B. i-lucide-mail) oder ein Emoji">
           <UInput v-model="form.icon" placeholder="i-lucide-mail" />
@@ -150,7 +141,7 @@ const grouped = computed(() => ({
       </div>
       <template #footer>
         <div class="flex gap-2">
-          <UButton :icon="editId ? 'i-lucide-save' : 'i-lucide-plus'" :loading="saving" data-test="snippet-save" @click="save">
+          <UButton :icon="editId ? 'i-lucide-save' : 'i-lucide-plus'" :loading="saving" data-test="prompt-save" @click="save">
             {{ editId ? 'Speichern' : 'Vorlage anlegen' }}
           </UButton>
           <UButton v-if="editId" variant="ghost" icon="i-lucide-x" @click="reset"> Abbrechen </UButton>
@@ -161,15 +152,15 @@ const grouped = computed(() => ({
     <UCard>
       <template #header><h2 class="font-semibold">Sichtbare Vorlagen</h2></template>
       <div v-if="loading" class="py-8 text-center text-muted"><UIcon name="i-lucide-loader-circle" class="size-6 animate-spin" /></div>
-      <div v-else-if="!snippets.length" class="py-8 text-center text-muted">Noch keine Vorlagen. Lege oben deine erste an.</div>
+      <div v-else-if="!prompts.length" class="py-8 text-center text-muted">Noch keine Vorlagen. Lege oben deine erste an.</div>
       <div v-else class="space-y-6">
         <template v-for="(group, key) in grouped" :key="key">
           <div v-if="group.length">
             <p class="mb-2 text-xs font-medium uppercase tracking-wide text-muted">
-              {{ key === 'user' ? 'Eigene' : key === 'tenant' ? 'Geteilt (Tenant)' : 'Global' }}
+              {{ key === 'user' ? 'Eigene (privat)' : 'Geteilt (Tenant)' }}
             </p>
             <div class="divide-y">
-              <div v-for="s in group" :key="s.id" class="flex items-start justify-between gap-3 py-3" data-test="snippet-row">
+              <div v-for="s in group" :key="s.id" class="flex items-start justify-between gap-3 py-3" data-test="prompt-row">
                 <div class="min-w-0">
                   <p class="flex flex-wrap items-center gap-2 font-medium">
                     <UIcon v-if="s.icon && s.icon.startsWith('i-')" :name="s.icon" class="size-4" />

--- a/nuxt-base-template/app/pages/app/settings/ai-prompts.vue
+++ b/nuxt-base-template/app/pages/app/settings/ai-prompts.vue
@@ -101,86 +101,96 @@ const grouped = computed(() => ({
 </script>
 
 <template>
-  <div class="mx-auto max-w-4xl space-y-6">
-    <div>
+  <div class="mx-auto max-w-7xl">
+    <div class="mb-6">
       <h1 class="text-2xl font-bold">KI-Vorlagen</h1>
       <p class="text-muted">
         Schnelle Textbausteine, die du im KI-Chat per Klick einfügen kannst. Sichtbarkeit: <strong>Privat</strong> (nur du) oder <strong>Tenant</strong> (alle Mitglieder deines
-        Tenants).
+        Tenants). Platzhalter wie <code>&#123;&#123;userId&#125;&#125;</code> werden beim Einfügen NICHT ersetzt — sie werden erst zur Laufzeit vom Backend aufgelöst, wenn die
+        Vorlage als Prompt abgeschickt wird.
       </p>
     </div>
 
-    <UAlert v-if="error" color="error" variant="subtle" icon="i-lucide-alert-circle" :description="error" />
+    <div class="grid gap-6 lg:grid-cols-[1fr_320px]">
+      <div class="space-y-6">
+        <UAlert v-if="error" color="error" variant="subtle" icon="i-lucide-alert-circle" :description="error" />
 
-    <UCard>
-      <template #header>
-        <h2 class="font-semibold">{{ editId ? 'Vorlage bearbeiten' : 'Neue Vorlage' }}</h2>
-      </template>
-      <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
-        <UFormField label="Name">
-          <UInput v-model="form.name" placeholder="z. B. Kurze freundliche Antwort" data-test="prompt-name" />
-        </UFormField>
-        <UFormField label="Sichtbarkeit">
-          <USelectMenu v-model="form.scope" :items="scopeItems" value-key="value" data-test="prompt-scope" />
-        </UFormField>
-        <UFormField label="Beschreibung" class="sm:col-span-2">
-          <UInput v-model="form.description" placeholder="Optional — wofür ist diese Vorlage?" />
-        </UFormField>
-        <UFormField label="Inhalt" class="sm:col-span-2" help="Wird beim Anklicken in den Chat-Eingabebereich eingefügt.">
-          <UTextarea v-model="form.content" :rows="4" placeholder="Beispiel: Schreibe eine kurze, freundliche Antwort an den Kunden zu …" data-test="prompt-content" />
-        </UFormField>
-        <UFormField label="Icon" help="Lucide-Name (z. B. i-lucide-mail) oder ein Emoji">
-          <UInput v-model="form.icon" placeholder="i-lucide-mail" />
-        </UFormField>
-        <UFormField label="Reihenfolge">
-          <UInput v-model.number="form.order" type="number" placeholder="100" />
-        </UFormField>
-        <UFormField label="Aktiv">
-          <USwitch v-model="form.enabled" />
-        </UFormField>
-      </div>
-      <template #footer>
-        <div class="flex gap-2">
-          <UButton :icon="editId ? 'i-lucide-save' : 'i-lucide-plus'" :loading="saving" data-test="prompt-save" @click="save">
-            {{ editId ? 'Speichern' : 'Vorlage anlegen' }}
-          </UButton>
-          <UButton v-if="editId" variant="ghost" icon="i-lucide-x" @click="reset"> Abbrechen </UButton>
-        </div>
-      </template>
-    </UCard>
+        <UCard>
+          <template #header>
+            <h2 class="font-semibold">{{ editId ? 'Vorlage bearbeiten' : 'Neue Vorlage' }}</h2>
+          </template>
+          <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            <UFormField label="Name">
+              <UInput v-model="form.name" placeholder="z. B. Kurze freundliche Antwort" data-test="prompt-name" />
+            </UFormField>
+            <UFormField label="Sichtbarkeit">
+              <USelectMenu v-model="form.scope" :items="scopeItems" value-key="value" data-test="prompt-scope" />
+            </UFormField>
+            <UFormField label="Beschreibung" class="sm:col-span-2">
+              <UInput v-model="form.description" placeholder="Optional — wofür ist diese Vorlage?" />
+            </UFormField>
+            <UFormField label="Inhalt" class="sm:col-span-2" help="Wird beim Anklicken in den Chat-Eingabebereich eingefügt.">
+              <UTextarea v-model="form.content" :rows="4" placeholder="Beispiel: Schreibe eine kurze, freundliche Antwort an den Kunden zu …" data-test="prompt-content" />
+            </UFormField>
+            <UFormField label="Icon" help="Lucide-Name (z. B. i-lucide-mail) oder ein Emoji">
+              <UInput v-model="form.icon" placeholder="i-lucide-mail" />
+            </UFormField>
+            <UFormField label="Reihenfolge">
+              <UInput v-model.number="form.order" type="number" placeholder="100" />
+            </UFormField>
+            <UFormField label="Aktiv">
+              <USwitch v-model="form.enabled" />
+            </UFormField>
+          </div>
+          <template #footer>
+            <div class="flex gap-2">
+              <UButton :icon="editId ? 'i-lucide-save' : 'i-lucide-plus'" :loading="saving" data-test="prompt-save" @click="save">
+                {{ editId ? 'Speichern' : 'Vorlage anlegen' }}
+              </UButton>
+              <UButton v-if="editId" variant="ghost" icon="i-lucide-x" @click="reset"> Abbrechen </UButton>
+            </div>
+          </template>
+        </UCard>
 
-    <UCard>
-      <template #header><h2 class="font-semibold">Sichtbare Vorlagen</h2></template>
-      <div v-if="loading" class="py-8 text-center text-muted"><UIcon name="i-lucide-loader-circle" class="size-6 animate-spin" /></div>
-      <div v-else-if="!prompts.length" class="py-8 text-center text-muted">Noch keine Vorlagen. Lege oben deine erste an.</div>
-      <div v-else class="space-y-6">
-        <template v-for="(group, key) in grouped" :key="key">
-          <div v-if="group.length">
-            <p class="mb-2 text-xs font-medium uppercase tracking-wide text-muted">
-              {{ key === 'user' ? 'Eigene (privat)' : 'Geteilt (Tenant)' }}
-            </p>
-            <div class="divide-y">
-              <div v-for="s in group" :key="s.id" class="flex items-start justify-between gap-3 py-3" data-test="prompt-row">
-                <div class="min-w-0">
-                  <p class="flex flex-wrap items-center gap-2 font-medium">
-                    <UIcon v-if="s.icon && s.icon.startsWith('i-')" :name="s.icon" class="size-4" />
-                    <span v-else-if="s.icon">{{ s.icon }}</span>
-                    <span>{{ s.name }}</span>
-                    <UBadge size="xs" variant="subtle">#{{ s.order ?? 100 }}</UBadge>
-                    <UBadge v-if="s.enabled === false" size="xs" color="warning" variant="subtle">inaktiv</UBadge>
-                  </p>
-                  <p v-if="s.description" class="text-xs text-muted">{{ s.description }}</p>
-                  <p class="mt-1 line-clamp-2 text-xs text-muted">{{ s.content }}</p>
-                </div>
-                <div class="flex shrink-0 items-center gap-1">
-                  <UButton v-if="canMutate(s)" size="sm" variant="ghost" icon="i-lucide-pencil" @click="edit(s)" />
-                  <UButton v-if="canMutate(s)" size="sm" variant="ghost" color="error" icon="i-lucide-trash" @click="onDelete(s)" />
+        <UCard>
+          <template #header><h2 class="font-semibold">Sichtbare Vorlagen</h2></template>
+          <div v-if="loading" class="py-8 text-center text-muted"><UIcon name="i-lucide-loader-circle" class="size-6 animate-spin" /></div>
+          <div v-else-if="!prompts.length" class="py-8 text-center text-muted">Noch keine Vorlagen. Lege oben deine erste an.</div>
+          <div v-else class="space-y-6">
+            <template v-for="(group, key) in grouped" :key="key">
+              <div v-if="group.length">
+                <p class="mb-2 text-xs font-medium uppercase tracking-wide text-muted">
+                  {{ key === 'user' ? 'Eigene (privat)' : 'Geteilt (Tenant)' }}
+                </p>
+                <div class="divide-y">
+                  <div v-for="s in group" :key="s.id" class="flex items-start justify-between gap-3 py-3" data-test="prompt-row">
+                    <div class="min-w-0">
+                      <p class="flex flex-wrap items-center gap-2 font-medium">
+                        <UIcon v-if="s.icon && s.icon.startsWith('i-')" :name="s.icon" class="size-4" />
+                        <span v-else-if="s.icon">{{ s.icon }}</span>
+                        <span>{{ s.name }}</span>
+                        <UBadge size="xs" variant="subtle">#{{ s.order ?? 100 }}</UBadge>
+                        <UBadge v-if="s.enabled === false" size="xs" color="warning" variant="subtle">inaktiv</UBadge>
+                      </p>
+                      <p v-if="s.description" class="text-xs text-muted">{{ s.description }}</p>
+                      <p class="mt-1 line-clamp-2 text-xs text-muted">{{ s.content }}</p>
+                    </div>
+                    <div class="flex shrink-0 items-center gap-1">
+                      <UButton v-if="canMutate(s)" size="sm" variant="ghost" icon="i-lucide-pencil" @click="edit(s)" />
+                      <UButton v-if="canMutate(s)" size="sm" variant="ghost" color="error" icon="i-lucide-trash" @click="onDelete(s)" />
+                    </div>
+                  </div>
                 </div>
               </div>
-            </div>
+            </template>
           </div>
-        </template>
+        </UCard>
       </div>
-    </UCard>
+
+      <!-- Placeholder helper sidebar -->
+      <aside class="space-y-4">
+        <AiPlaceholderHint />
+      </aside>
+    </div>
   </div>
 </template>

--- a/nuxt-base-template/app/pages/app/settings/ai-prompts.vue
+++ b/nuxt-base-template/app/pages/app/settings/ai-prompts.vue
@@ -15,7 +15,12 @@ const { user } = useLtAuth();
 const toast = useToast();
 const { create, error, load, loading, remove, prompts, update } = useLtAiPrompts();
 
-const isAdmin = computed(() => Array.isArray(user.value?.roles) && user.value!.roles!.includes('admin'));
+// nest-server users carry roles as an array (`roles: string[]`); some Better Auth
+// setups additionally expose a singular `role`. Accept either.
+const isAdmin = computed(() => {
+  const u = user.value as { role?: string; roles?: string[] } | null;
+  return !!u?.roles?.includes('admin') || u?.role === 'admin';
+});
 const myUserId = computed(() => user.value?.id);
 
 const scopeItems = [

--- a/nuxt-base-template/app/pages/app/settings/ai-prompts.vue
+++ b/nuxt-base-template/app/pages/app/settings/ai-prompts.vue
@@ -10,17 +10,13 @@
 import type { LtAiPrompt, LtAiPromptInput } from '@lenne.tech/nuxt-extensions';
 
 useHead({ title: 'KI-Vorlagen' });
+definePageMeta({ ssr: false });
 
 const { user } = useLtAuth();
 const toast = useToast();
 const { create, error, load, loading, remove, prompts, update } = useLtAiPrompts();
 
-// nest-server users carry roles as an array (`roles: string[]`); some Better Auth
-// setups additionally expose a singular `role`. Accept either.
-const isAdmin = computed(() => {
-  const u = user.value as { role?: string; roles?: string[] } | null;
-  return !!u?.roles?.includes('admin') || u?.role === 'admin';
-});
+const isAdmin = computed(() => isAdminUser(user.value));
 const myUserId = computed(() => user.value?.id);
 
 const scopeItems = [

--- a/nuxt-base-template/app/pages/app/settings/ai-snippets.vue
+++ b/nuxt-base-template/app/pages/app/settings/ai-snippets.vue
@@ -1,0 +1,195 @@
+<script setup lang="ts">
+// ============================================================================
+// User-facing AI prompt snippets ("Vorlagen") settings:
+//   - list every snippet visible to the current user (own + tenant + global)
+//   - CRUD for own snippets
+//   - share with the whole tenant (no admin role needed)
+//   - admins additionally see / can author `global` snippets
+//
+// Owner-only mutations are enforced server-side; admins can edit any snippet
+// via the standard admin pipeline.
+// ============================================================================
+import type { LtAiPromptSnippet, LtAiPromptSnippetInput } from '@lenne.tech/nuxt-extensions';
+
+useHead({ title: 'KI-Vorlagen' });
+
+const { user } = useLtAuth();
+const toast = useToast();
+const { create, error, load, loading, remove, snippets, update } = useLtAiSnippets();
+
+const isAdmin = computed(() => Array.isArray(user.value?.roles) && user.value!.roles!.includes('admin'));
+const myUserId = computed(() => user.value?.id);
+
+const scopeItems = computed(() => {
+  const items = [
+    { label: 'Nur für mich', value: 'user' },
+    { label: 'Tenant teilen', value: 'tenant' },
+  ];
+  if (isAdmin.value) {
+    items.push({ label: 'Global (alle)', value: 'global' });
+  }
+  return items;
+});
+
+function emptyForm(): LtAiPromptSnippetInput {
+  return { content: '', description: '', enabled: true, icon: '', name: '', order: 100, scope: 'user' };
+}
+
+const form = reactive<LtAiPromptSnippetInput>(emptyForm());
+const editId = ref<null | string>(null);
+const saving = ref(false);
+
+onMounted(load);
+
+function canMutate(s: LtAiPromptSnippet): boolean {
+  return isAdmin.value || s.ownerId === myUserId.value;
+}
+
+function reset(): void {
+  editId.value = null;
+  Object.assign(form, emptyForm());
+}
+
+function edit(s: LtAiPromptSnippet): void {
+  editId.value = s.id;
+  Object.assign(form, {
+    content: s.content || '',
+    description: s.description || '',
+    enabled: s.enabled !== false,
+    icon: s.icon || '',
+    name: s.name || '',
+    order: s.order ?? 100,
+    scope: s.scope || 'user',
+  });
+}
+
+async function save(): Promise<void> {
+  if (!form.name?.trim()) {
+    toast.add({ color: 'error', description: 'Bitte einen Namen angeben.', title: 'Fehler' });
+    return;
+  }
+  if (!form.content?.trim()) {
+    toast.add({ color: 'error', description: 'Bitte einen Inhalt angeben.', title: 'Fehler' });
+    return;
+  }
+  saving.value = true;
+  try {
+    const payload: LtAiPromptSnippetInput = { ...form };
+    if (editId.value) {
+      await update(editId.value, payload);
+      toast.add({ color: 'success', description: 'Vorlage aktualisiert.', title: 'Erfolg' });
+    } else {
+      await create(payload);
+      toast.add({ color: 'success', description: 'Vorlage angelegt.', title: 'Erfolg' });
+    }
+    reset();
+  } catch (err) {
+    toast.add({ color: 'error', description: (err as Error).message, title: 'Fehler' });
+  } finally {
+    saving.value = false;
+  }
+}
+
+async function onDelete(s: LtAiPromptSnippet): Promise<void> {
+  try {
+    await remove(s.id);
+    toast.add({ color: 'success', description: 'Vorlage gelöscht.', title: 'Erfolg' });
+    if (editId.value === s.id) {
+      reset();
+    }
+  } catch (err) {
+    toast.add({ color: 'error', description: (err as Error).message, title: 'Fehler' });
+  }
+}
+
+const grouped = computed(() => ({
+  user: snippets.value.filter((s) => s.scope === 'user'),
+  tenant: snippets.value.filter((s) => s.scope === 'tenant'),
+  global: snippets.value.filter((s) => s.scope === 'global'),
+}));
+</script>
+
+<template>
+  <div class="mx-auto max-w-4xl space-y-6">
+    <div>
+      <h1 class="text-2xl font-bold">KI-Vorlagen</h1>
+      <p class="text-muted">
+        Schnelle Textbausteine, die du im KI-Chat per Klick einfügen kannst. Sichtbarkeit: <strong>Nur für mich</strong>, <strong>Tenant</strong> (alle Mitglieder deines Tenants)
+        oder <strong>Global</strong> (alle Nutzer — nur Admins).
+      </p>
+    </div>
+
+    <UAlert v-if="error" color="error" variant="subtle" icon="i-lucide-alert-circle" :description="error" />
+
+    <UCard>
+      <template #header>
+        <h2 class="font-semibold">{{ editId ? 'Vorlage bearbeiten' : 'Neue Vorlage' }}</h2>
+      </template>
+      <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <UFormField label="Name">
+          <UInput v-model="form.name" placeholder="z. B. Kurze freundliche Antwort" data-test="snippet-name" />
+        </UFormField>
+        <UFormField label="Sichtbarkeit">
+          <USelectMenu v-model="form.scope" :items="scopeItems" value-key="value" data-test="snippet-scope" />
+        </UFormField>
+        <UFormField label="Beschreibung" class="sm:col-span-2">
+          <UInput v-model="form.description" placeholder="Optional — wofür ist diese Vorlage?" />
+        </UFormField>
+        <UFormField label="Inhalt" class="sm:col-span-2" help="Wird beim Anklicken in den Chat-Eingabebereich eingefügt.">
+          <UTextarea v-model="form.content" :rows="4" placeholder="Beispiel: Schreibe eine kurze, freundliche Antwort an den Kunden zu …" data-test="snippet-content" />
+        </UFormField>
+        <UFormField label="Icon" help="Lucide-Name (z. B. i-lucide-mail) oder ein Emoji">
+          <UInput v-model="form.icon" placeholder="i-lucide-mail" />
+        </UFormField>
+        <UFormField label="Reihenfolge">
+          <UInput v-model.number="form.order" type="number" placeholder="100" />
+        </UFormField>
+        <UFormField label="Aktiv">
+          <USwitch v-model="form.enabled" />
+        </UFormField>
+      </div>
+      <template #footer>
+        <div class="flex gap-2">
+          <UButton :icon="editId ? 'i-lucide-save' : 'i-lucide-plus'" :loading="saving" data-test="snippet-save" @click="save">
+            {{ editId ? 'Speichern' : 'Vorlage anlegen' }}
+          </UButton>
+          <UButton v-if="editId" variant="ghost" icon="i-lucide-x" @click="reset"> Abbrechen </UButton>
+        </div>
+      </template>
+    </UCard>
+
+    <UCard>
+      <template #header><h2 class="font-semibold">Sichtbare Vorlagen</h2></template>
+      <div v-if="loading" class="py-8 text-center text-muted"><UIcon name="i-lucide-loader-circle" class="size-6 animate-spin" /></div>
+      <div v-else-if="!snippets.length" class="py-8 text-center text-muted">Noch keine Vorlagen. Lege oben deine erste an.</div>
+      <div v-else class="space-y-6">
+        <template v-for="(group, key) in grouped" :key="key">
+          <div v-if="group.length">
+            <p class="mb-2 text-xs font-medium uppercase tracking-wide text-muted">
+              {{ key === 'user' ? 'Eigene' : key === 'tenant' ? 'Geteilt (Tenant)' : 'Global' }}
+            </p>
+            <div class="divide-y">
+              <div v-for="s in group" :key="s.id" class="flex items-start justify-between gap-3 py-3" data-test="snippet-row">
+                <div class="min-w-0">
+                  <p class="flex flex-wrap items-center gap-2 font-medium">
+                    <UIcon v-if="s.icon && s.icon.startsWith('i-')" :name="s.icon" class="size-4" />
+                    <span v-else-if="s.icon">{{ s.icon }}</span>
+                    <span>{{ s.name }}</span>
+                    <UBadge size="xs" variant="subtle">#{{ s.order ?? 100 }}</UBadge>
+                    <UBadge v-if="s.enabled === false" size="xs" color="warning" variant="subtle">inaktiv</UBadge>
+                  </p>
+                  <p v-if="s.description" class="text-xs text-muted">{{ s.description }}</p>
+                  <p class="mt-1 line-clamp-2 text-xs text-muted">{{ s.content }}</p>
+                </div>
+                <div class="flex shrink-0 items-center gap-1">
+                  <UButton v-if="canMutate(s)" size="sm" variant="ghost" icon="i-lucide-pencil" @click="edit(s)" />
+                  <UButton v-if="canMutate(s)" size="sm" variant="ghost" color="error" icon="i-lucide-trash" @click="onDelete(s)" />
+                </div>
+              </div>
+            </div>
+          </div>
+        </template>
+      </div>
+    </UCard>
+  </div>
+</template>

--- a/nuxt-base-template/app/pages/app/settings/ai.vue
+++ b/nuxt-base-template/app/pages/app/settings/ai.vue
@@ -46,17 +46,15 @@ function pct(used: number, max?: number): number {
       </template>
 
       <div class="space-y-3">
-        <UAlert
-          v-if="locked"
-          color="info"
-          variant="subtle"
-          icon="i-lucide-lock"
-          description="Die Verbindung ist vorgegeben und kann nicht geändert werden."
-        />
+        <UAlert v-if="locked" color="info" variant="subtle" icon="i-lucide-lock" description="Die Verbindung ist vorgegeben und kann nicht geändert werden." />
         <p v-if="!connections.length" class="py-4 text-center text-muted">Keine KI-Verbindung verfügbar.</p>
         <div v-for="conn in connections" :key="conn.id" class="flex items-center justify-between py-2">
           <div class="flex items-center gap-3">
-            <UIcon :name="conn.id === selected?.id ? 'i-lucide-check-circle' : 'i-lucide-circle'" class="size-5" :class="conn.id === selected?.id ? 'text-primary' : 'text-muted'" />
+            <UIcon
+              :name="conn.id === selected?.id ? 'i-lucide-check-circle' : 'i-lucide-circle'"
+              class="size-5"
+              :class="conn.id === selected?.id ? 'text-primary' : 'text-muted'"
+            />
             <div>
               <p class="font-medium">{{ conn.name || conn.id }}</p>
               <p class="text-xs text-muted">{{ conn.model }}<span v-if="conn.isDefault"> · Standard</span></p>

--- a/nuxt-base-template/app/pages/app/settings/ai.vue
+++ b/nuxt-base-template/app/pages/app/settings/ai.vue
@@ -3,6 +3,7 @@
 // User AI settings: pick the personal default connection and view token usage.
 // ============================================================================
 useHead({ title: 'KI-Einstellungen' });
+definePageMeta({ ssr: false });
 
 const toast = useToast();
 const { connections, load: loadConnections, locked, select, selected } = useLtAiConnections();

--- a/nuxt-base-template/app/pages/app/settings/ai.vue
+++ b/nuxt-base-template/app/pages/app/settings/ai.vue
@@ -1,0 +1,105 @@
+<script setup lang="ts">
+// ============================================================================
+// User AI settings: pick the personal default connection and view token usage.
+// ============================================================================
+useHead({ title: 'KI-Einstellungen' });
+
+const toast = useToast();
+const { connections, load: loadConnections, locked, select, selected } = useLtAiConnections();
+const { load: loadUsage, usage } = useLtAiUsage();
+
+onMounted(async () => {
+  await Promise.all([loadConnections(), loadUsage()]);
+});
+
+async function choose(id: string): Promise<void> {
+  try {
+    await select(id);
+    toast.add({ color: 'success', description: 'Standard-Verbindung gespeichert.', title: 'Erfolg' });
+  } catch (err) {
+    toast.add({ color: 'error', description: (err as Error).message, title: 'Fehler' });
+  }
+}
+
+function pct(used: number, max?: number): number {
+  return max && max > 0 ? Math.min(100, Math.round((used / max) * 100)) : 0;
+}
+</script>
+
+<template>
+  <div class="mx-auto max-w-2xl space-y-8">
+    <div>
+      <h1 class="text-2xl font-bold">KI-Einstellungen</h1>
+      <p class="text-muted">Wähle deine bevorzugte KI-Verbindung und sieh deinen Verbrauch.</p>
+    </div>
+
+    <!-- Connection selection -->
+    <UCard>
+      <template #header>
+        <div class="flex items-center gap-3">
+          <UIcon name="i-lucide-plug" class="size-6 text-primary" />
+          <div>
+            <h2 class="font-semibold">KI-Verbindung</h2>
+            <p class="text-sm text-muted">Deine Standard-Verbindung für Anfragen</p>
+          </div>
+        </div>
+      </template>
+
+      <div class="space-y-3">
+        <UAlert
+          v-if="locked"
+          color="info"
+          variant="subtle"
+          icon="i-lucide-lock"
+          description="Die Verbindung ist vorgegeben und kann nicht geändert werden."
+        />
+        <p v-if="!connections.length" class="py-4 text-center text-muted">Keine KI-Verbindung verfügbar.</p>
+        <div v-for="conn in connections" :key="conn.id" class="flex items-center justify-between py-2">
+          <div class="flex items-center gap-3">
+            <UIcon :name="conn.id === selected?.id ? 'i-lucide-check-circle' : 'i-lucide-circle'" class="size-5" :class="conn.id === selected?.id ? 'text-primary' : 'text-muted'" />
+            <div>
+              <p class="font-medium">{{ conn.name || conn.id }}</p>
+              <p class="text-xs text-muted">{{ conn.model }}<span v-if="conn.isDefault"> · Standard</span></p>
+            </div>
+          </div>
+          <UButton v-if="conn.id !== selected?.id" size="sm" variant="outline" :disabled="locked" @click="choose(conn.id)"> Auswählen </UButton>
+          <UBadge v-else color="primary" variant="subtle">Aktiv</UBadge>
+        </div>
+      </div>
+    </UCard>
+
+    <!-- Usage -->
+    <UCard>
+      <template #header>
+        <div class="flex items-center gap-3">
+          <UIcon name="i-lucide-gauge" class="size-6 text-primary" />
+          <div>
+            <h2 class="font-semibold">Verbrauch</h2>
+            <p class="text-sm text-muted">Dein Token-Kontingent im aktuellen Zeitraum</p>
+          </div>
+        </div>
+      </template>
+
+      <div v-if="usage?.user" class="space-y-4">
+        <div>
+          <div class="mb-1 flex justify-between text-sm">
+            <span class="text-muted">Tokens</span>
+            <span class="font-medium">
+              {{ usage.user.usedTokens }}<template v-if="usage.user.maxTokens"> / {{ usage.user.maxTokens }}</template>
+            </span>
+          </div>
+          <UProgress v-if="usage.user.maxTokens" :model-value="pct(usage.user.usedTokens, usage.user.maxTokens)" />
+          <p v-else class="text-xs text-muted">Unbegrenzt</p>
+        </div>
+        <div class="flex justify-between text-sm">
+          <span class="text-muted">Anfragen</span>
+          <span class="font-medium">
+            {{ usage.user.usedPrompts }}<template v-if="usage.user.maxPrompts"> / {{ usage.user.maxPrompts }}</template>
+          </span>
+        </div>
+        <p v-if="usage.user.resetAt" class="text-xs text-muted">Zurücksetzung: {{ new Date(usage.user.resetAt).toLocaleString('de-DE') }}</p>
+      </div>
+      <p v-else class="py-4 text-center text-muted">Keine Verbrauchsdaten verfügbar.</p>
+    </UCard>
+  </div>
+</template>

--- a/nuxt-base-template/app/pages/auth/login.vue
+++ b/nuxt-base-template/app/pages/auth/login.vue
@@ -121,6 +121,24 @@ async function onPasskeyLogin(): Promise<void> {
 }
 
 // ============================================================================
+// Race-safe submit guard (capture-phase preventDefault)
+// ============================================================================
+// Vue's `<UAuthForm>` handler calls `event.preventDefault()` inside its bubble
+// listener — but that listener is attached during per-component hydration. If a
+// user (or an automated/MCP test) submits the form BEFORE this listener has
+// attached, the browser performs the native form GET — leaking the password
+// into the URL. This capture-phase listener attaches as soon as the wrapper
+// mounts and unconditionally prevents the default, closing that race window.
+// Vue's own bubble handler still runs once attached and performs the real sign-in.
+const formRoot = ref<HTMLElement | null>(null);
+onMounted(() => {
+  const form = formRoot.value?.querySelector?.('form');
+  if (form instanceof HTMLFormElement) {
+    form.addEventListener('submit', (event) => event.preventDefault(), { capture: true });
+  }
+});
+
+// ============================================================================
 // Functions
 // ============================================================================
 async function onSubmit(payload: FormSubmitEvent<Schema>): Promise<void> {
@@ -192,34 +210,36 @@ async function onSubmit(payload: FormSubmitEvent<Schema>): Promise<void> {
 
 <template>
   <UPageCard class="w-md" variant="naked">
-    <UAuthForm
-      :schema="schema"
-      title="Anmelden"
-      icon="i-lucide-user"
-      :fields="fields"
-      :loading="loading"
-      :submit="{
-        label: 'Anmelden',
-        block: true,
-      }"
-      @submit="onSubmit"
-    >
-      <template #password-hint>
-        <ULink to="/auth/forgot-password" class="text-primary font-medium" tabindex="-1">Passwort vergessen?</ULink>
-      </template>
+    <div ref="formRoot">
+      <UAuthForm
+        :schema="schema"
+        title="Anmelden"
+        icon="i-lucide-user"
+        :fields="fields"
+        :loading="loading"
+        :submit="{
+          label: 'Anmelden',
+          block: true,
+        }"
+        @submit="onSubmit"
+      >
+        <template #password-hint>
+          <ULink to="/auth/forgot-password" class="text-primary font-medium" tabindex="-1">Passwort vergessen?</ULink>
+        </template>
 
-      <template #footer>
-        <div class="flex flex-col gap-4">
-          <USeparator label="oder" />
+        <template #footer>
+          <div class="flex flex-col gap-4">
+            <USeparator label="oder" />
 
-          <UButton block color="neutral" variant="outline" icon="i-lucide-key" :loading="passkeyLoading" @click="onPasskeyLogin"> Mit Passkey anmelden </UButton>
+            <UButton block color="neutral" variant="outline" icon="i-lucide-key" :loading="passkeyLoading" @click="onPasskeyLogin"> Mit Passkey anmelden </UButton>
 
-          <p v-if="features.signUpEnabled !== false" class="text-center text-sm text-muted">
-            Noch kein Konto?
-            <ULink to="/auth/register" class="text-primary font-medium">Registrieren</ULink>
-          </p>
-        </div>
-      </template>
-    </UAuthForm>
+            <p v-if="features.signUpEnabled !== false" class="text-center text-sm text-muted">
+              Noch kein Konto?
+              <ULink to="/auth/register" class="text-primary font-medium">Registrieren</ULink>
+            </p>
+          </div>
+        </template>
+      </UAuthForm>
+    </div>
   </UPageCard>
 </template>

--- a/nuxt-base-template/app/pages/auth/register.vue
+++ b/nuxt-base-template/app/pages/auth/register.vue
@@ -139,6 +139,22 @@ const schema = computed(() => (requireTerms.value ? termsSchema : baseSchema));
 type Schema = InferOutput<typeof baseSchema> | InferOutput<typeof termsSchema>;
 
 // ============================================================================
+// Race-safe submit guard (capture-phase preventDefault)
+// ============================================================================
+// `<UAuthForm>`'s onSubmit calls preventDefault inside its bubble listener,
+// which only attaches during component hydration. If a fast user / automated
+// test submits before that, the browser runs the native form GET and leaks
+// the password into the URL. This capture-phase listener attaches as soon as
+// the wrapper mounts and unconditionally prevents the default.
+const formRoot = ref<HTMLElement | null>(null);
+onMounted(() => {
+  const form = formRoot.value?.querySelector?.('form');
+  if (form instanceof HTMLFormElement) {
+    form.addEventListener('submit', (event) => event.preventDefault(), { capture: true });
+  }
+});
+
+// ============================================================================
 // Functions
 // ============================================================================
 async function onSubmit(payload: FormSubmitEvent<Schema>): Promise<void> {
@@ -247,38 +263,40 @@ async function skipPasskey(): Promise<void> {
 <template>
   <UPageCard class="w-md" variant="naked">
     <template v-if="!showPasskeyPrompt">
-      <UAuthForm
-        :schema="schema"
-        title="Registrieren"
-        icon="i-lucide-user-plus"
-        :fields="fields"
-        :loading="loading"
-        :submit="{
-          label: 'Konto erstellen',
-          block: true,
-        }"
-        @submit="onSubmit"
-      >
-        <template v-if="requireTerms" #termsAccepted-field="slotProps">
-          <UCheckbox v-model="(slotProps as any).state.termsAccepted">
-            <template #label>
-              <span class="text-sm">
-                Ich akzeptiere die
-                <ULink to="/legal/terms" class="text-primary font-medium" target="_blank">AGB</ULink>
-                und
-                <ULink to="/legal/privacy" class="text-primary font-medium" target="_blank">Datenschutzerklärung</ULink>
-              </span>
-            </template>
-          </UCheckbox>
-        </template>
+      <div ref="formRoot">
+        <UAuthForm
+          :schema="schema"
+          title="Registrieren"
+          icon="i-lucide-user-plus"
+          :fields="fields"
+          :loading="loading"
+          :submit="{
+            label: 'Konto erstellen',
+            block: true,
+          }"
+          @submit="onSubmit"
+        >
+          <template v-if="requireTerms" #termsAccepted-field="slotProps">
+            <UCheckbox v-model="(slotProps as any).state.termsAccepted">
+              <template #label>
+                <span class="text-sm">
+                  Ich akzeptiere die
+                  <ULink to="/legal/terms" class="text-primary font-medium" target="_blank">AGB</ULink>
+                  und
+                  <ULink to="/legal/privacy" class="text-primary font-medium" target="_blank">Datenschutzerklärung</ULink>
+                </span>
+              </template>
+            </UCheckbox>
+          </template>
 
-        <template #footer>
-          <p class="text-center text-sm text-muted">
-            Bereits ein Konto?
-            <ULink to="/auth/login" class="text-primary font-medium">Anmelden</ULink>
-          </p>
-        </template>
-      </UAuthForm>
+          <template #footer>
+            <p class="text-center text-sm text-muted">
+              Bereits ein Konto?
+              <ULink to="/auth/login" class="text-primary font-medium">Anmelden</ULink>
+            </p>
+          </template>
+        </UAuthForm>
+      </div>
     </template>
 
     <template v-else>

--- a/nuxt-base-template/app/utils/is-admin-user.ts
+++ b/nuxt-base-template/app/utils/is-admin-user.ts
@@ -1,0 +1,9 @@
+// nest-server users carry roles as an array (`roles: string[]`); some Better
+// Auth setups additionally expose a singular `role`. Accept either so the admin
+// gate stays consistent across middleware, layout nav, and per-page checks.
+// LtUser only declares `role` — `roles` comes from the nest-server projection.
+export type IsAdminUserCandidate = { role?: string; roles?: string[] } | null | undefined;
+
+export function isAdminUser(user: IsAdminUserCandidate): boolean {
+  return !!user?.roles?.includes('admin') || user?.role === 'admin';
+}

--- a/nuxt-base-template/nuxt.config.ts
+++ b/nuxt-base-template/nuxt.config.ts
@@ -123,7 +123,6 @@ export default defineNuxtConfig({
     '@nuxt/test-utils/module', // E2E testing with Playwright
     '@lenne.tech/bug.lt', // Bug reporting to Linear
     '@vueuse/nuxt', // Vue composition utilities
-    'dayjs-nuxt', // Date/time handling
     '@nuxt/image', // Image optimization
     '@nuxt/ui', // NuxtUI component library
     '@nuxtjs/plausible', // Privacy-friendly analytics

--- a/nuxt-base-template/nuxt.config.ts
+++ b/nuxt-base-template/nuxt.config.ts
@@ -83,6 +83,11 @@ export default defineNuxtConfig({
   // lenne.tech Nuxt Extensions
   // ============================================================================
   ltExtensions: {
+    ai: {
+      // AI assistant composables. basePath must match the nest-server AI controller.
+      enabled: true,
+      basePath: '/ai',
+    },
     auth: {
       enabled: true,
       // baseURL: resolved at runtime via NUXT_PUBLIC_API_URL (not baked at build time)

--- a/nuxt-base-template/package.json
+++ b/nuxt-base-template/package.json
@@ -74,7 +74,6 @@
     "@types/qrcode": "1.5.6",
     "@vitejs/plugin-vue": "6.0.7",
     "@vue/test-utils": "2.4.10",
-    "dayjs-nuxt": "2.1.11",
     "happy-dom": "20.9.0",
     "lint-staged": "17.0.5",
     "mongodb": "7.2.0",

--- a/nuxt-base-template/package.json
+++ b/nuxt-base-template/package.json
@@ -48,21 +48,21 @@
     "fix": "pnpm run lint:fix && pnpm run format"
   },
   "dependencies": {
-    "@better-auth/passkey": "1.6.11",
+    "@better-auth/passkey": "1.6.13",
     "@lenne.tech/bug.lt": "latest",
-    "@lenne.tech/nuxt-extensions": "1.6.0",
+    "@lenne.tech/nuxt-extensions": "1.7.1",
     "@nuxt/image": "2.0.0",
-    "@nuxt/ui": "4.8.0",
+    "@nuxt/ui": "4.8.1",
     "@pinia/nuxt": "0.11.3",
     "@vueuse/nuxt": "14.3.0",
-    "better-auth": "1.6.11",
+    "better-auth": "1.6.13",
     "qrcode": "1.5.4",
     "tus-js-client": "4.3.1",
-    "valibot": "1.4.0"
+    "valibot": "1.4.1"
   },
   "devDependencies": {
-    "@hey-api/openapi-ts": "0.97.2",
-    "@iconify-json/lucide": "1.2.109",
+    "@hey-api/openapi-ts": "0.97.3",
+    "@iconify-json/lucide": "1.2.111",
     "@nuxt/devtools": "3.2.4",
     "@nuxt/test-utils": "4.0.3",
     "@nuxtjs/plausible": "3.0.2",
@@ -75,7 +75,7 @@
     "@vitejs/plugin-vue": "6.0.7",
     "@vue/test-utils": "2.4.10",
     "happy-dom": "20.9.0",
-    "lint-staged": "17.0.5",
+    "lint-staged": "17.0.7",
     "mongodb": "7.2.0",
     "nuxt": "4.4.6",
     "oxfmt": "0.28.0",
@@ -85,7 +85,7 @@
     "tailwindcss": "4.3.0",
     "typescript": "6.0.3",
     "vitest": "4.1.7",
-    "vue": "3.5.33"
+    "vue": "3.5.35"
   },
   "simple-git-hooks": {
     "pre-commit": "npx lint-staged",

--- a/nuxt-base-template/pnpm-lock.yaml
+++ b/nuxt-base-template/pnpm-lock.yaml
@@ -43,29 +43,29 @@ importers:
   .:
     dependencies:
       '@better-auth/passkey':
-        specifier: 1.6.11
-        version: 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.1.1))(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-auth@1.6.11(mongodb@7.2.0)(vitest@4.1.7(@types/node@25.9.1)(happy-dom@20.9.0)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3)))(vue@3.5.33(typescript@6.0.3)))(better-call@1.3.5(zod@4.3.6))(nanostores@1.1.1)
+        specifier: 1.6.13
+        version: 1.6.13(@better-auth/core@1.6.13(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.1.1))(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(better-auth@1.6.13(mongodb@7.2.0)(vitest@4.1.7(@types/node@25.9.1)(happy-dom@20.9.0)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3)))(vue@3.5.35(typescript@6.0.3)))(better-call@1.3.5(zod@4.3.6))(nanostores@1.1.1)
       '@lenne.tech/bug.lt':
         specifier: latest
-        version: 1.6.5(@babel/parser@7.29.3)(db0@0.3.4)(embla-carousel@8.6.0)(ioredis@5.10.1)(magicast@0.5.2)(qrcode@1.5.4)(typescript@6.0.3)(valibot@1.4.0(typescript@6.0.3))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.33(typescript@6.0.3))
+        version: 1.6.5(@babel/parser@7.29.3)(db0@0.3.4)(embla-carousel@8.6.0)(ioredis@5.10.1)(magicast@0.5.2)(qrcode@1.5.4)(typescript@6.0.3)(valibot@1.4.1(typescript@6.0.3))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.35(typescript@6.0.3))
       '@lenne.tech/nuxt-extensions':
-        specifier: 1.6.0
-        version: 1.6.0(64c77fc7986b0151ab228ee70fc2833c)
+        specifier: 1.7.1
+        version: 1.7.1(dc7c69ad612f89fa79dd9b9ed5300da1)
       '@nuxt/image':
         specifier: 2.0.0
         version: 2.0.0(db0@0.3.4)(ioredis@5.10.1)(magicast@0.5.2)
       '@nuxt/ui':
-        specifier: 4.8.0
-        version: 4.8.0(@internationalized/date@3.12.0)(@internationalized/number@3.6.5)(@tiptap/extensions@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5))(@tiptap/y-tiptap@3.0.2(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.6)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29))(db0@0.3.4)(embla-carousel@8.6.0)(ioredis@5.10.1)(magicast@0.5.2)(qrcode@1.5.4)(tailwindcss@4.3.0)(typescript@6.0.3)(valibot@1.4.0(typescript@6.0.3))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.33(typescript@6.0.3))(yjs@13.6.29)(zod@4.3.6)
+        specifier: 4.8.1
+        version: 4.8.1(@internationalized/date@3.12.0)(@internationalized/number@3.6.5)(@tiptap/extensions@3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0))(@tiptap/y-tiptap@3.0.2(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.6)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29))(db0@0.3.4)(embla-carousel@8.6.0)(ioredis@5.10.1)(magicast@0.5.2)(qrcode@1.5.4)(tailwindcss@4.3.0)(typescript@6.0.3)(valibot@1.4.1(typescript@6.0.3))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.35(typescript@6.0.3))(yjs@13.6.29)(zod@4.3.6)
       '@pinia/nuxt':
         specifier: 0.11.3
-        version: 0.11.3(magicast@0.5.2)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.33(typescript@6.0.3)))
+        version: 0.11.3(magicast@0.5.2)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))
       '@vueuse/nuxt':
         specifier: 14.3.0
-        version: 14.3.0(magicast@0.5.2)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(oxlint@1.43.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.33(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3))(vue@3.5.33(typescript@6.0.3))
+        version: 14.3.0(magicast@0.5.2)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(oxlint@1.43.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3))(vue@3.5.35(typescript@6.0.3))
       better-auth:
-        specifier: 1.6.11
-        version: 1.6.11(mongodb@7.2.0)(vitest@4.1.7(@types/node@25.9.1)(happy-dom@20.9.0)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3)))(vue@3.5.33(typescript@6.0.3))
+        specifier: 1.6.13
+        version: 1.6.13(mongodb@7.2.0)(vitest@4.1.7(@types/node@25.9.1)(happy-dom@20.9.0)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3)))(vue@3.5.35(typescript@6.0.3))
       qrcode:
         specifier: 1.5.4
         version: 1.5.4
@@ -73,27 +73,27 @@ importers:
         specifier: 4.3.1
         version: 4.3.1
       valibot:
-        specifier: 1.4.0
-        version: 1.4.0(typescript@6.0.3)
+        specifier: 1.4.1
+        version: 1.4.1(typescript@6.0.3)
     devDependencies:
       '@hey-api/openapi-ts':
-        specifier: 0.97.2
-        version: 0.97.2(magicast@0.5.2)(typescript@6.0.3)
+        specifier: 0.97.3
+        version: 0.97.3(magicast@0.5.2)(typescript@6.0.3)
       '@iconify-json/lucide':
-        specifier: 1.2.109
-        version: 1.2.109
+        specifier: 1.2.111
+        version: 1.2.111
       '@nuxt/devtools':
         specifier: 3.2.4
-        version: 3.2.4(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.33(typescript@6.0.3))
+        version: 3.2.4(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.35(typescript@6.0.3))
       '@nuxt/test-utils':
         specifier: 4.0.3
-        version: 4.0.3(@playwright/test@1.60.0)(@vue/test-utils@2.4.10(@vue/compiler-dom@3.5.34)(@vue/server-renderer@3.5.34(vue@3.5.33(typescript@6.0.3)))(vue@3.5.33(typescript@6.0.3)))(happy-dom@20.9.0)(magicast@0.5.2)(playwright-core@1.60.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vitest@4.1.7(@types/node@25.9.1)(happy-dom@20.9.0)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3)))
+        version: 4.0.3(@playwright/test@1.60.0)(@vue/test-utils@2.4.10(@vue/compiler-dom@3.5.35)(@vue/server-renderer@3.5.35(vue@3.5.35(typescript@6.0.3)))(vue@3.5.35(typescript@6.0.3)))(happy-dom@20.9.0)(magicast@0.5.2)(playwright-core@1.60.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vitest@4.1.7(@types/node@25.9.1)(happy-dom@20.9.0)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3)))
       '@nuxtjs/plausible':
         specifier: 3.0.2
         version: 3.0.2(magicast@0.5.2)
       '@nuxtjs/seo':
         specifier: 5.1.3
-        version: 5.1.3(2f74cd97bddeef2f5008a0e24db0c8ac)
+        version: 5.1.3(a560e8cf9cca550f7c08acddc759a1d4)
       '@playwright/test':
         specifier: 1.60.0
         version: 1.60.0
@@ -111,22 +111,22 @@ importers:
         version: 1.5.6
       '@vitejs/plugin-vue':
         specifier: 6.0.7
-        version: 6.0.7(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.33(typescript@6.0.3))
+        version: 6.0.7(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.35(typescript@6.0.3))
       '@vue/test-utils':
         specifier: 2.4.10
-        version: 2.4.10(@vue/compiler-dom@3.5.34)(@vue/server-renderer@3.5.34(vue@3.5.33(typescript@6.0.3)))(vue@3.5.33(typescript@6.0.3))
+        version: 2.4.10(@vue/compiler-dom@3.5.35)(@vue/server-renderer@3.5.35(vue@3.5.35(typescript@6.0.3)))(vue@3.5.35(typescript@6.0.3))
       happy-dom:
         specifier: 20.9.0
         version: 20.9.0
       lint-staged:
-        specifier: 17.0.5
-        version: 17.0.5
+        specifier: 17.0.7
+        version: 17.0.7
       mongodb:
         specifier: 7.2.0
         version: 7.2.0
       nuxt:
         specifier: 4.4.6
-        version: 4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(oxlint@1.43.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.33(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3)
+        version: 4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(oxlint@1.43.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3)
       oxfmt:
         specifier: 0.28.0
         version: 0.28.0
@@ -149,8 +149,8 @@ importers:
         specifier: 4.1.7
         version: 4.1.7(@types/node@25.9.1)(happy-dom@20.9.0)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))
       vue:
-        specifier: 3.5.33
-        version: 3.5.33(typescript@6.0.3)
+        specifier: 3.5.35
+        version: 3.5.35(typescript@6.0.3)
 
 packages:
 
@@ -260,11 +260,6 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  '@babel/parser@7.29.2':
-    resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-
   '@babel/parser@7.29.3':
     resolution: {integrity: sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==}
     engines: {node: '>=6.0.0'}
@@ -309,10 +304,10 @@ packages:
     resolution: {integrity: sha512-JeSVu/m8x/zpp4CLjYHVNXuhEyOkhPXuxM8YOXjh6L4LlvQNKuUNOTo5KdBuKAcTDHw8DquToTaEkhsBqPXOaA==}
     engines: {node: ^22.18.0 || >=24.11.0}
 
-  '@better-auth/core@1.6.11':
-    resolution: {integrity: sha512-LrwidLCV8azdMGjvtwp30nj9tIv1BwI3VhtC0UaGSjQkAVWw4bN42I8qwbxRziPeSQoj+zUVkOpxZzAWBDARtQ==}
+  '@better-auth/core@1.6.13':
+    resolution: {integrity: sha512-3YNjiLUmlNt5T9qQ/weu0tZgGgXDSYax4EE/uLUBIBBGtQI9Q3KdEnO6tfPgDedborcSE1bIspuAIaHpaHwxZQ==}
     peerDependencies:
-      '@better-auth/utils': 0.4.0
+      '@better-auth/utils': 0.4.1
       '@better-fetch/fetch': 1.1.21
       '@cloudflare/workers-types': '>=4'
       '@opentelemetry/api': ^1.9.0
@@ -326,57 +321,57 @@ packages:
       '@opentelemetry/api':
         optional: true
 
-  '@better-auth/drizzle-adapter@1.6.11':
-    resolution: {integrity: sha512-4jpkETIGZOHCf7BK4jnu22fdN6jjomH0/HhEzkaWy3+Eppi5PYlHTF/460jrTmA3Xc+Vqwp9t282ymHiEPypGw==}
+  '@better-auth/drizzle-adapter@1.6.13':
+    resolution: {integrity: sha512-0V6e+e7TnIZZDjhQP/tvAberSrdrf5yfbDSx5oDFsfI5MCh2ATvbuTPNxGWbLdbGnUYfbX4K9FZwzKMj8RpLmg==}
     peerDependencies:
-      '@better-auth/core': ^1.6.11
-      '@better-auth/utils': 0.4.0
+      '@better-auth/core': ^1.6.13
+      '@better-auth/utils': 0.4.1
       drizzle-orm: ^0.45.2
     peerDependenciesMeta:
       drizzle-orm:
         optional: true
 
-  '@better-auth/kysely-adapter@1.6.11':
-    resolution: {integrity: sha512-/g8M9RfIjdcZDnbstSUvQiINkvdNlCeZr248zwqx2/PVksQI1MhQofbzUn3RnQnbPKp0EPwpX/dR3oudRFenUg==}
+  '@better-auth/kysely-adapter@1.6.13':
+    resolution: {integrity: sha512-r+TeBL9dJecuCaSMqL3106qwaXYL3GAkoJDfmtbZ2eZ/Ejr9xVj5msJnSULb0ZqyQ1g5SCbnM39WZaCOFirziQ==}
     peerDependencies:
-      '@better-auth/core': ^1.6.11
-      '@better-auth/utils': 0.4.0
-      kysely: ^0.28.17
+      '@better-auth/core': ^1.6.13
+      '@better-auth/utils': 0.4.1
+      kysely: ^0.28.17 || ^0.29.0
     peerDependenciesMeta:
       kysely:
         optional: true
 
-  '@better-auth/memory-adapter@1.6.11':
-    resolution: {integrity: sha512-hpdfw0BBf8MuzLkIdmbcUZICbY9r/bhLO2RxSnkzT5+/O+0I0u2I8+m0YUP7vNllP/ZCKASHOYgXPLO75Z0f9Q==}
+  '@better-auth/memory-adapter@1.6.13':
+    resolution: {integrity: sha512-upmNncEwm9Q0MpWLVOdx9Pe3fU/aqobO80zwI+WVCavxmL59SufW5Ud7194/J5ushw4Dd52XNn0XWPJT1ZUThg==}
     peerDependencies:
-      '@better-auth/core': ^1.6.11
-      '@better-auth/utils': 0.4.0
+      '@better-auth/core': ^1.6.13
+      '@better-auth/utils': 0.4.1
 
-  '@better-auth/mongo-adapter@1.6.11':
-    resolution: {integrity: sha512-3Tor8rSv8vSEIMEaV2PFpPEuVhqc1gNoZ6eGvoh3LwExXXuj8madew6ob+H1pH7Aphn3Ar5PQ08AguT8TbwFAA==}
+  '@better-auth/mongo-adapter@1.6.13':
+    resolution: {integrity: sha512-u0g5KThZQInx4QxsaXDJ+Yg5A9z/ia/3EBwi+gI7+kSTKkeT9PZZ6J+erwJ5Sh4d0JUQsEX2DX2YRsg/mYnXWQ==}
     peerDependencies:
-      '@better-auth/core': ^1.6.11
-      '@better-auth/utils': 0.4.0
+      '@better-auth/core': ^1.6.13
+      '@better-auth/utils': 0.4.1
       mongodb: ^6.0.0 || ^7.0.0
     peerDependenciesMeta:
       mongodb:
         optional: true
 
-  '@better-auth/passkey@1.6.11':
-    resolution: {integrity: sha512-QjL+OyiKRSHFRhSp2CSe7u5jnRL5G+Eh4bW9eV4WFZQ+2a/S+113kHQxPqxhy3Onb5cQhkT5Bhyz7cxKNDJTPw==}
+  '@better-auth/passkey@1.6.13':
+    resolution: {integrity: sha512-vgHcOo0UUA4U6DANi1/TJTCAA7q0zxFurIB75tA6L72NGWdWSqqNH+83TKNxuuL78IeH0Vqk6qhDK0BfdiJA2Q==}
     peerDependencies:
-      '@better-auth/core': ^1.6.11
-      '@better-auth/utils': 0.4.0
+      '@better-auth/core': ^1.6.13
+      '@better-auth/utils': 0.4.1
       '@better-fetch/fetch': 1.1.21
-      better-auth: ^1.6.11
+      better-auth: ^1.6.13
       better-call: 1.3.5
       nanostores: ^1.0.1
 
-  '@better-auth/prisma-adapter@1.6.11':
-    resolution: {integrity: sha512-Pw+7q7zTp+VSci1V+CYMvuxIbAeVMZLe4lRo46LJoAKMHfjFl5T/ycsyFvWs/DkWC7n9gZZzRDEbHp0I5FiKKw==}
+  '@better-auth/prisma-adapter@1.6.13':
+    resolution: {integrity: sha512-gjmUIdqmxWb4WoNEN5rTQYQli6A9fPopAaVDiLh/gwO3ET10/PuOEwfESePEwUbArlKLLK3hPEWWe0RBojyxgQ==}
     peerDependencies:
-      '@better-auth/core': ^1.6.11
-      '@better-auth/utils': 0.4.0
+      '@better-auth/core': ^1.6.13
+      '@better-auth/utils': 0.4.1
       '@prisma/client': ^5.0.0 || ^6.0.0 || ^7.0.0
       prisma: ^5.0.0 || ^6.0.0 || ^7.0.0
     peerDependenciesMeta:
@@ -385,15 +380,18 @@ packages:
       prisma:
         optional: true
 
-  '@better-auth/telemetry@1.6.11':
-    resolution: {integrity: sha512-hsjDHc8MZbm6/AHeNdtywrWedXevnBjmdvnHTcZub+rTVjOv+Td0roI8USKuC6uUibmrl//2rJfVCsGbopihNA==}
+  '@better-auth/telemetry@1.6.13':
+    resolution: {integrity: sha512-CXfPPL55mZrGH1FUhZOw9REp2WRJoVjCh9egn+cIx3ReB/OnPz+eHSRft/IVLD2PQyP1FNr1Au89SXd2oPBUPg==}
     peerDependencies:
-      '@better-auth/core': ^1.6.11
-      '@better-auth/utils': 0.4.0
+      '@better-auth/core': ^1.6.13
+      '@better-auth/utils': 0.4.1
       '@better-fetch/fetch': 1.1.21
 
   '@better-auth/utils@0.4.0':
     resolution: {integrity: sha512-RpMtLUIQAEWMgdPLNVbIF5ON2mm+CH0U3rCdUCU1VyeAUui4m38DyK7/aXMLZov2YDjG684pS1D0MBllrmgjQA==}
+
+  '@better-auth/utils@0.4.1':
+    resolution: {integrity: sha512-SZBPRPF3z0nBvE5ygOkxae35wnnXPRShmqFo78S+qslLeFoPu/pMgnXAuNKFMMybac3tiLaVg1e3MQW5MC+1iA==}
 
   '@better-fetch/fetch@1.1.21':
     resolution: {integrity: sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A==}
@@ -963,23 +961,23 @@ packages:
   '@hexagon/base64@1.1.28':
     resolution: {integrity: sha512-lhqDEAvWixy3bZ+UOYbPwUbBkwBq5C1LAJ/xPC8Oi+lL54oyakv/npbA0aU2hgCsx/1NUd4IBvV03+aUBWxerw==}
 
-  '@hey-api/codegen-core@0.8.1':
-    resolution: {integrity: sha512-Iciv2vUCJTW9lWM/ROvyZLblmcbYJHPuXfzb1SzeDVVn4xEXu2ilLU1pq3fn+09FZ/Y0P7VyvRE47UDU6om8xA==}
+  '@hey-api/codegen-core@0.8.2':
+    resolution: {integrity: sha512-R2NMf3wq97rh1mjz33WJQU8svz3F0RYUjvx/QzXucjpSqQ3O5huTdDjErG4fMxSr1X+X56NuDrqtGfHmo1TRUQ==}
     engines: {node: '>=22.13.0'}
 
   '@hey-api/json-schema-ref-parser@1.4.2':
     resolution: {integrity: sha512-ZhCFSKI2ipZHEbgmtUHdyddvRU3wJ4elgCfYUC7T7hZa4EivSrVflTQf2w+v3TuaYxR1Y2V2kq3otqTttrrK8Q==}
     engines: {node: '>=22.13.0'}
 
-  '@hey-api/openapi-ts@0.97.2':
-    resolution: {integrity: sha512-nA+y0/I5O9loQMeJKumi6BQ40/Y71N0hIMmXZ/I7rh8jEOzYxSxmf5a4TBEI2Ap4RAfZyh7RJzJfVzT98KUYQQ==}
+  '@hey-api/openapi-ts@0.97.3':
+    resolution: {integrity: sha512-4sR6/E/POuy7aPZW9DDjhObzZCq7eSJWiW0+epXeKNczoTWEwdOyWFy9Ca/CnXYlZ3oJsrv0ZD0OO+YuczT7CA==}
     engines: {node: '>=22.13.0'}
     hasBin: true
     peerDependencies:
       typescript: '>=5.5.3 || >=6.0.0 || 6.0.1-rc'
 
-  '@hey-api/shared@0.4.4':
-    resolution: {integrity: sha512-UZgaQNEdo/OSGLeNXhSv0VQTHQQm5Q2mHOuoYhFPJkNvLVrz7KZtGdKR8O4QPrhyblshxY+caJli08WKM0gREg==}
+  '@hey-api/shared@0.4.5':
+    resolution: {integrity: sha512-au4eHpBXAe1du0iMp6ESYuEaMS2jsoEyrbcT246btRhI9rMeQFEs7ZjtcMGXGsxhpaR38A8cPGNHx7QOrWAdMw==}
     engines: {node: '>=22.13.0'}
 
   '@hey-api/spec-types@0.2.0':
@@ -988,8 +986,8 @@ packages:
   '@hey-api/types@0.1.4':
     resolution: {integrity: sha512-thWfawrDIP7wSI9ioT13I5soaaqB5vAPIiZmgD8PbeEVKNrkonc0N/Sjj97ezl7oQgusZmaNphGdMKipPO6IBg==}
 
-  '@iconify-json/lucide@1.2.109':
-    resolution: {integrity: sha512-O5arvTVcu95soP3dGWJp/Nl5L5FYmFu2z75sSrQmGzrgrnsCU49t8+ZB7HPq//GRNXpWUoNfDRcs5yR7XMa+zw==}
+  '@iconify-json/lucide@1.2.111':
+    resolution: {integrity: sha512-S6oXom2YOKuXFxWofhHa2oq++Z3WeZ78dRFDA7aEEJqyNCJlQd1UGAfN8u2gD2NzvYotmm+j5kH678viWfZbGQ==}
 
   '@iconify/collections@1.0.648':
     resolution: {integrity: sha512-0365h8NN+PXjUXc32cmaQaulext6S6Jnx1+6XxU5ivzNiQWmMlh6W1BkF9wncH+e48yzL1Tqes2A17WwYieZtw==}
@@ -1093,8 +1091,8 @@ packages:
   '@lenne.tech/bug.lt@1.6.5':
     resolution: {integrity: sha512-3aSfAcuizL8WvmDaHUlSjpLVdaeSRtNMrEPle7IoqA9VBmfaCfUKzOQmSdnz69Laeq6hn1a2P1HVcsj1QoOWuQ==}
 
-  '@lenne.tech/nuxt-extensions@1.6.0':
-    resolution: {integrity: sha512-l5M/8Pu8v2ffoWJ2qavQxHCcXvyj0acVod4/Dexy+l9ZxzIGYuJiFtNDsoHCAm7AZuhhMKU4l1WZIhBVikggOw==}
+  '@lenne.tech/nuxt-extensions@1.7.1':
+    resolution: {integrity: sha512-pBqJsYkX4/JFRal+pSrlRDSzLxsJRGihk3LVU1OSoMfMIAbP/SkW1/Zur0ut28PgtLK/H7BsDMlk3nN3mcIIRA==}
     peerDependencies:
       '@better-auth/passkey': '>=1.0.0'
       '@playwright/test': '>=1.0.0'
@@ -1340,6 +1338,45 @@ packages:
 
   '@nuxt/ui@4.8.0':
     resolution: {integrity: sha512-ymnGxvMCYtPzuMGIK/fnd41/Arh9hxfmz9m5auaf51jg/zhSpAkIesTVSv0at+bGKXxwtQZoPS9GXs0+SzWfjg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@inertiajs/vue3': ^2.0.7 || ^3.0.0
+      '@internationalized/date': ^3.0.0
+      '@internationalized/number': ^3.0.0
+      '@nuxt/content': ^3.0.0
+      joi: ^18.0.0
+      superstruct: ^2.0.0
+      tailwindcss: ^4.0.0
+      typescript: ^5.6.3 || ^6.0.0
+      valibot: ^1.0.0
+      vue-router: ^4.5.0 || ^5.0.0
+      yup: ^1.7.0
+      zod: ^3.24.0 || ^4.0.0
+    peerDependenciesMeta:
+      '@inertiajs/vue3':
+        optional: true
+      '@internationalized/date':
+        optional: true
+      '@internationalized/number':
+        optional: true
+      '@nuxt/content':
+        optional: true
+      joi:
+        optional: true
+      superstruct:
+        optional: true
+      valibot:
+        optional: true
+      vue-router:
+        optional: true
+      yup:
+        optional: true
+      zod:
+        optional: true
+
+  '@nuxt/ui@4.8.1':
+    resolution: {integrity: sha512-mS5Lxmv7FiLn7C6ww4XAQUs3aUa5Nrb/ZzGFP1SAc0gMUjyG0Y71nJe+wxtMPf/afq6QOPSdhu+I2sLhOd4j4w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -2935,6 +2972,9 @@ packages:
   '@tanstack/virtual-core@3.14.0':
     resolution: {integrity: sha512-JLANqGy/D6k4Ujmh8Tr25lGimuOXNiaVyXaCAZS0W+1390sADdGnyUdSWNIfd49gebtIxGMij4IktRVzrdr12Q==}
 
+  '@tanstack/virtual-core@3.16.0':
+    resolution: {integrity: sha512-Er2N7q3WOiH6y2JLxsxNX+u2/sLqSsL0bxFgDjuiPiA7vKhZRm+IzcS17vRee3GNXr64UsesA5CAp9yTiIYw9A==}
+
   '@tanstack/vue-table@8.21.3':
     resolution: {integrity: sha512-rusRyd77c5tDPloPskctMyPLFEQUeBzxdQ+2Eow4F7gDPlPOB1UnnhzfpdvqZ8ZyX2rRNGmqNnQWm87OI2OQPw==}
     engines: {node: '>=12'}
@@ -2951,20 +2991,40 @@ packages:
     peerDependencies:
       vue: ^2.7.0 || ^3.0.0
 
+  '@tanstack/vue-virtual@3.13.26':
+    resolution: {integrity: sha512-4TmREKi8rKiQC8E2XVEMMgzWbrgHNYolkBgYTXVK1kqXmXRGz6xPWgBq20GUYWUDDhit94+g0ricUQKpZhWRmg==}
+    peerDependencies:
+      vue: ^2.7.0 || ^3.0.0
+
   '@tiptap/core@3.22.5':
     resolution: {integrity: sha512-L1lhWz6ujGny8LduTJ7MBWYhzigwOvfUJUrJ7IzOJSuy3+OAzisdGDD1GV7LEO/hU0Hr2Mkm1wajRIHExvS9HQ==}
     peerDependencies:
       '@tiptap/pm': 3.22.5
+
+  '@tiptap/core@3.24.0':
+    resolution: {integrity: sha512-GTAsXAI32p4hEZgPzvUv2RPrObxamy9AFhmhG10fXSvN/cDUs8naEYVIqDV3Sh99jMwQEbTFKW1E1mcspsY6ow==}
+    peerDependencies:
+      '@tiptap/pm': 3.24.0
 
   '@tiptap/extension-blockquote@3.22.5':
     resolution: {integrity: sha512-ajyP5W8fG5Hrru47T/eF3xMKOpNvWofgNJqBTeNuGl02sYxsy9a4EunyFxudsaZP9WW3VOD4SaIWr5+MqpbnOQ==}
     peerDependencies:
       '@tiptap/core': 3.22.5
 
+  '@tiptap/extension-blockquote@3.24.0':
+    resolution: {integrity: sha512-DgwEEJ1GbDQcT054ynxoaZGmB9apGeUklPrinq9o6xdLHpdg+bO9HCQzggdB8n21VLLglb8jfAEWsVNwh3eASQ==}
+    peerDependencies:
+      '@tiptap/core': 3.24.0
+
   '@tiptap/extension-bold@3.22.5':
     resolution: {integrity: sha512-l/uDtpJISiFFyfctvnODNWBN/XPZI1jVZRacTRDDnSn8+x6KQ7G2qgFYueU7KvVJGDFVT39Iio56mcFRG/Pozg==}
     peerDependencies:
       '@tiptap/core': 3.22.5
+
+  '@tiptap/extension-bold@3.24.0':
+    resolution: {integrity: sha512-CujogYaynasklFKHADUseuvj8X2FnWktTCCo3Hl+nlyRvBTmm5TK2aqiamg3v2P4dBh3O6a70mo8BfRJPuiR1g==}
+    peerDependencies:
+      '@tiptap/core': 3.24.0
 
   '@tiptap/extension-bubble-menu@3.22.5':
     resolution: {integrity: sha512-yrNlFQQJY5MmhBpmD8tnmaSmyUQrEvgyPKa3bzVeWEhDSG1CW4A0ZSMx3hrA9yFO0HWfw3IJmvSCycEZQBalpQ==}
@@ -2972,10 +3032,21 @@ packages:
       '@tiptap/core': 3.22.5
       '@tiptap/pm': 3.22.5
 
+  '@tiptap/extension-bubble-menu@3.24.0':
+    resolution: {integrity: sha512-jRXD+JPu9ayvq78g8hsCxx4q/qUFtrdfIYirRSf5YUseuuUbtfrq83AsGabcygpUTefjJkMQoXNITkh6294Ggw==}
+    peerDependencies:
+      '@tiptap/core': 3.24.0
+      '@tiptap/pm': 3.24.0
+
   '@tiptap/extension-bullet-list@3.22.5':
     resolution: {integrity: sha512-cf54fG9AybU8NgPMv1TOcoqAkELeRc/VpnSCt/rIJZphWQx9nsFmrtkrlCatrIcCaGtNZYwlHlMnC5LVVMu0uA==}
     peerDependencies:
       '@tiptap/extension-list': 3.22.5
+
+  '@tiptap/extension-bullet-list@3.24.0':
+    resolution: {integrity: sha512-IOpAm5c4XVVVvkOef+V9XYMVpea+3MgBpCQgn83UQRlwO9eIMwmcyxOznu7gQPQVShTEpkt4T6uK+ZN9o8meIA==}
+    peerDependencies:
+      '@tiptap/extension-list': 3.24.0
 
   '@tiptap/extension-code-block@3.22.5':
     resolution: {integrity: sha512-d123kCfLdJTi4fue1m0+TNFztDkmIRSZGZmGu6H9KqwG5Q7IzjT9o8lzRsz+pXxYqHvqgYmXoEpM6srbzXx/Ag==}
@@ -2983,10 +3054,21 @@ packages:
       '@tiptap/core': 3.22.5
       '@tiptap/pm': 3.22.5
 
+  '@tiptap/extension-code-block@3.24.0':
+    resolution: {integrity: sha512-NZglw4oHoH6oJ5+HvxxQCYk+wODJmsxzUpRQdsOmje08sekQH+Zt9i4UKimBhg4urpd5r+dKXTslab9a5eQ86w==}
+    peerDependencies:
+      '@tiptap/core': 3.24.0
+      '@tiptap/pm': 3.24.0
+
   '@tiptap/extension-code@3.22.5':
     resolution: {integrity: sha512-mwDNOJC9rYbDu/JcqrN4dbUQRklJU8Fuk2raxD/IvFw9qUIcPCmxQ2XT9UTKmZz/Ju7Kdy72fss6XpgWv6gLAQ==}
     peerDependencies:
       '@tiptap/core': 3.22.5
+
+  '@tiptap/extension-code@3.24.0':
+    resolution: {integrity: sha512-MAQtrPRQ+HRmcGotWbksdIGeH1gqayFAdvi4lNGeFT7taHXP1o1XD7CQp7iYIKmg8IU4/MQ+RdetSfuC1A9edQ==}
+    peerDependencies:
+      '@tiptap/core': 3.24.0
 
   '@tiptap/extension-collaboration@3.22.5':
     resolution: {integrity: sha512-3rax34HKSo8L5ihv5iGxISNBUIdVP0Fq9O6T/mq4kQOLhVhNbqwr9I/lWOvaz24nPE7u5Vkz0Ii3zWGlzxyPPA==}
@@ -2996,10 +3078,23 @@ packages:
       '@tiptap/y-tiptap': ^3.0.2
       yjs: ^13
 
+  '@tiptap/extension-collaboration@3.24.0':
+    resolution: {integrity: sha512-PF9rFZrZtgr7xemnzQaU1uScUz4GwDjE+vLMosugUJxaoz/zSsHRXQ00dHM32MKxBzbWg3A4ZQTHB7YzAtyl3Q==}
+    peerDependencies:
+      '@tiptap/core': 3.24.0
+      '@tiptap/pm': 3.24.0
+      '@tiptap/y-tiptap': ^3.0.4
+      yjs: ^13
+
   '@tiptap/extension-document@3.22.5':
     resolution: {integrity: sha512-8NJERd+pCtvSuEP4C4WMGYmRRCV12ePZL7bC+QUdFlbdXg+kNZS0zZ7hh879tYA0Kidbi8rWWD1Tx+H2ezkmMw==}
     peerDependencies:
       '@tiptap/core': 3.22.5
+
+  '@tiptap/extension-document@3.24.0':
+    resolution: {integrity: sha512-yxgM3+yXy2XZzEwH43y2Kp8D1BkblxEWLXqo0YCoAKtxyKCcEaT8kdlf70kS7D0+VSzYU4D0iN7VdQIYHcL2mA==}
+    peerDependencies:
+      '@tiptap/core': 3.24.0
 
   '@tiptap/extension-drag-handle-vue-3@3.22.5':
     resolution: {integrity: sha512-8Uc47c2gdzDrLJpel+gk29yhLlDlLsG3rr5BUa1Grss3PhMGBYepb66ErAVimgW+6l+aw1eFAOMm03WkGDU/kQ==}
@@ -3007,6 +3102,14 @@ packages:
       '@tiptap/extension-drag-handle': 3.22.5
       '@tiptap/pm': 3.22.5
       '@tiptap/vue-3': 3.22.5
+      vue: ^3.0.0
+
+  '@tiptap/extension-drag-handle-vue-3@3.24.0':
+    resolution: {integrity: sha512-tk9yKgGPYMRAKeCtEdza532EZzbIID7pO6sSLqmteyDH3MxuaJZLhi6tqRheWm55SlPTTJzAUZuY8EchzPpC7g==}
+    peerDependencies:
+      '@tiptap/extension-drag-handle': 3.24.0
+      '@tiptap/pm': 3.24.0
+      '@tiptap/vue-3': 3.24.0
       vue: ^3.0.0
 
   '@tiptap/extension-drag-handle@3.22.5':
@@ -3018,10 +3121,24 @@ packages:
       '@tiptap/pm': 3.22.5
       '@tiptap/y-tiptap': ^3.0.2
 
+  '@tiptap/extension-drag-handle@3.24.0':
+    resolution: {integrity: sha512-DMW2Dx89aS28+FXlpl5nlkZT4dhqdaAO6W76qXVUPIHFvO5yWP0q5UzAPGW5JEBOI+LxWj0AkTDMrX0XrLw9oA==}
+    peerDependencies:
+      '@tiptap/core': 3.24.0
+      '@tiptap/extension-collaboration': 3.24.0
+      '@tiptap/extension-node-range': 3.24.0
+      '@tiptap/pm': 3.24.0
+      '@tiptap/y-tiptap': ^3.0.2
+
   '@tiptap/extension-dropcursor@3.22.5':
     resolution: {integrity: sha512-Mp40DaFrY3sEUVtFqmxrR0BmU4G3k8GCYYNGqNa9OqWv7BrcFDC03V2n3okESDKt4MKkzhQQmypq+ouLy8dLfA==}
     peerDependencies:
       '@tiptap/extensions': 3.22.5
+
+  '@tiptap/extension-dropcursor@3.24.0':
+    resolution: {integrity: sha512-Dbv1c5LnvG3PT+yEbCNroyOeeUkHq9wcir2pbC7wri7g7d2sCi0+HvKH0MAxLwY3j5NJJSiSyG2ypMaXOAs4sg==}
+    peerDependencies:
+      '@tiptap/extensions': 3.24.0
 
   '@tiptap/extension-floating-menu@3.22.5':
     resolution: {integrity: sha512-dhem4sTPhyQgQ+pFp2Oud4k4FSQz9PVMgeQAC9288SmGwxBkJNveDAw6sKTMrumqDvwkJrtslXIupq9TZYQnzg==}
@@ -3030,20 +3147,42 @@ packages:
       '@tiptap/core': 3.22.5
       '@tiptap/pm': 3.22.5
 
+  '@tiptap/extension-floating-menu@3.24.0':
+    resolution: {integrity: sha512-7QEbf3mUzFAkejjQGX9f0L507oMtnOBRwHt2skUTR+9yXgudsN8zaDBSSRHLeMWGk9b7L293ZMA6zCRrZaHrfA==}
+    peerDependencies:
+      '@floating-ui/dom': ^1.0.0
+      '@tiptap/core': 3.24.0
+      '@tiptap/pm': 3.24.0
+
   '@tiptap/extension-gapcursor@3.22.5':
     resolution: {integrity: sha512-4WkMu7qqjbsm8hCQS+8X+la1wjriN0SKoRdvpfKH33qM50MB34tYJuGLAO+y7TTh4MMMco3AZCKPBL5JVMqNIg==}
     peerDependencies:
       '@tiptap/extensions': 3.22.5
+
+  '@tiptap/extension-gapcursor@3.24.0':
+    resolution: {integrity: sha512-CzCP5/jni5RFwW9jCfBO6auh83GbaioMTpSk6tyR3sd+CbwlBcUdsJFGJkbaRdiSS9dgIyi+6hRbhjpYdHcp+w==}
+    peerDependencies:
+      '@tiptap/extensions': 3.24.0
 
   '@tiptap/extension-hard-break@3.22.5':
     resolution: {integrity: sha512-n0R2mUVYZU2AVbJhg/WcY9+zx690wVwvsItHJf0DrYbf1tCYHx+PRHUt/AoXk6u8BSmnkb8/FDziS8m3mjfpSg==}
     peerDependencies:
       '@tiptap/core': 3.22.5
 
+  '@tiptap/extension-hard-break@3.24.0':
+    resolution: {integrity: sha512-T/ZEBiHQPMyTqDvXG0tiqBToNeuSemIPmNtdoGSgBN/degVl7VJZqQIrLIvOUHfjf3QkRs7TE/mcqTJsIboO/g==}
+    peerDependencies:
+      '@tiptap/core': 3.24.0
+
   '@tiptap/extension-heading@3.22.5':
     resolution: {integrity: sha512-hjyEG4947PAhMBfP1G6B0QAh6+y9mp2C5BQmNjprA05/lQzDAT7KFZzNh8ZVp3ol6aICKq/N1gFOW9Dc/9FUOw==}
     peerDependencies:
       '@tiptap/core': 3.22.5
+
+  '@tiptap/extension-heading@3.24.0':
+    resolution: {integrity: sha512-GCSgapIzQPqEGNcVGE0/Pcjg5wITMLYJlrS3GGVw7BPmECJwgexcoOsEwkxtzJnXT/HpFXbvOFW43sM0KeHSjg==}
+    peerDependencies:
+      '@tiptap/core': 3.24.0
 
   '@tiptap/extension-horizontal-rule@3.22.5':
     resolution: {integrity: sha512-vUV0/ugIbXOc8SJib0h8UMhgcqZXWu/dkEhlswZN4VVven1o5enkfxEiDw+OyIJHi5rUkrdhsQ/KTxG/Xb7X8A==}
@@ -3051,15 +3190,31 @@ packages:
       '@tiptap/core': 3.22.5
       '@tiptap/pm': 3.22.5
 
+  '@tiptap/extension-horizontal-rule@3.24.0':
+    resolution: {integrity: sha512-DFzWJTrb23x+qssLLs85vEyho8ItUGp3RY9XUsVTIAGZn5IsoUw8wMsvIBlH1ux4Ch7gLchtcD6kpTdMdrL9kw==}
+    peerDependencies:
+      '@tiptap/core': 3.24.0
+      '@tiptap/pm': 3.24.0
+
   '@tiptap/extension-image@3.22.5':
     resolution: {integrity: sha512-ezMzA6w6UsPesQp6fxTQojI/IkGJLmkwR/VGTimva7sudP3HdSW8k3SGBkjfvp0L2xqUrC/l4nWOchu01A/xtQ==}
     peerDependencies:
       '@tiptap/core': 3.22.5
 
+  '@tiptap/extension-image@3.24.0':
+    resolution: {integrity: sha512-mH+bvsX2cPKuZzV7YMQi4FV2YbDP+Kmq36bY+Bwi/x4mYUc8u0cjQxcu8RzLO7GtsgUJPxGMwfkQxmDqXFLZvw==}
+    peerDependencies:
+      '@tiptap/core': 3.24.0
+
   '@tiptap/extension-italic@3.22.5':
     resolution: {integrity: sha512-4T8baSiLkeIymTgEwirxDFt5YgYofkP3m1+MGYdGy2HKcOK+1vpvlPhEO1X5qtZngtJW5S4+njKjinRg52A4PA==}
     peerDependencies:
       '@tiptap/core': 3.22.5
+
+  '@tiptap/extension-italic@3.24.0':
+    resolution: {integrity: sha512-mf3cbNlbMPUNj3IyUkIke+o3ZpOUrtVeY5Yqs5IM/VhkUUh/PdIzqw74VuqEAJ0Z4oZ6nNDHeYLrl3Be1j99lQ==}
+    peerDependencies:
+      '@tiptap/core': 3.24.0
 
   '@tiptap/extension-link@3.22.5':
     resolution: {integrity: sha512-d671MvF3GPKoS2OVxjIlQ7hIE7MS3hREdR+d4cvnnoiLLD+ZJ6KgDnxmWqF0a1s4qxLWK2KxKRSOIfYGE31QWQ==}
@@ -3067,21 +3222,43 @@ packages:
       '@tiptap/core': 3.22.5
       '@tiptap/pm': 3.22.5
 
+  '@tiptap/extension-link@3.24.0':
+    resolution: {integrity: sha512-MwMoNGG2mL5XGFV1tEGunBRglwsIbW+ZOB2QnKiv+Mcbi2JCWMrorndJZBqpVPR5nM+Bef2KnpchEJmYlQLvKQ==}
+    peerDependencies:
+      '@tiptap/core': 3.24.0
+      '@tiptap/pm': 3.24.0
+
   '@tiptap/extension-list-item@3.22.5':
     resolution: {integrity: sha512-W7uTmyKLhlsvuTPLv+8WwnsY+mlikBFIoLSvVcBaFt4MwpsZ+DeB6KQg02Y7tbtaAnG7rXu9Fvw2QORh2P728A==}
     peerDependencies:
       '@tiptap/extension-list': 3.22.5
+
+  '@tiptap/extension-list-item@3.24.0':
+    resolution: {integrity: sha512-zl/U3viJiV9OzkKM37AHIUN1af1TSLrcbHUUoNLkfJ33Nq+NlpaXpCVK0rKRqiLFJf7zk/a5KWG5CrOy9TxjKA==}
+    peerDependencies:
+      '@tiptap/extension-list': 3.24.0
 
   '@tiptap/extension-list-keymap@3.22.5':
     resolution: {integrity: sha512-cGUnxJ0y515e1bVHNjUmbx7oWHoEon59w6BA5N2KwV9iW2mZZchlTX4yxJSOX+ixeVRChsa7YwC3Z1jUZ6AMEg==}
     peerDependencies:
       '@tiptap/extension-list': 3.22.5
 
+  '@tiptap/extension-list-keymap@3.24.0':
+    resolution: {integrity: sha512-69fKcrngYGEKWNn4R5oLwl0YuV3FY4kufEValVcjnihUmqJTE1vx+fwctYoTsOGnIuNGpUIQ7f9YDD/0w34qBw==}
+    peerDependencies:
+      '@tiptap/extension-list': 3.24.0
+
   '@tiptap/extension-list@3.22.5':
     resolution: {integrity: sha512-cVO3ZHCgxAWZ4zrFSs81FO2nyCk1wb2EHkpLpW98FzbJLkN9rDkazhW99P3HRWy/CvUldOT+8ecI1YrQtBojMg==}
     peerDependencies:
       '@tiptap/core': 3.22.5
       '@tiptap/pm': 3.22.5
+
+  '@tiptap/extension-list@3.24.0':
+    resolution: {integrity: sha512-GcxDVMMmDGj7OFTBrV7JpVgr5wxlr2vmjwH7U8QxZX7OJI5vrsMYl/U6KRTvUpG8wP+Zmo5jRlLM+BbL+a/W3g==}
+    peerDependencies:
+      '@tiptap/core': 3.24.0
+      '@tiptap/pm': 3.24.0
 
   '@tiptap/extension-mention@3.22.5':
     resolution: {integrity: sha512-rGTbTjyxLc5C/6QjfbQF53nMbxjVgJU1VK6Si1i1J2c5DU09COgEFlYvi4YHjb3xz39SprPfG+GTtgD96eg7Ww==}
@@ -3090,41 +3267,84 @@ packages:
       '@tiptap/pm': 3.22.5
       '@tiptap/suggestion': 3.22.5
 
+  '@tiptap/extension-mention@3.24.0':
+    resolution: {integrity: sha512-c68AYrEoHJ4vlBvt5stBUTveKXiNwt5BxaQxgq2R4OXjc3VMoh+XJqo1bBbMNHEJfuGMNpcdfZ2zf09jnBf8/A==}
+    peerDependencies:
+      '@tiptap/core': 3.24.0
+      '@tiptap/pm': 3.24.0
+      '@tiptap/suggestion': 3.24.0
+
   '@tiptap/extension-node-range@3.22.5':
     resolution: {integrity: sha512-1C00Dur+8KNjcKcI6nuYY4RFOrp/1YUFR04Wj0VZVc8L8l4jCXS+JY+aYtTwKjxcXIH3UzplfwoRZj9thn98pg==}
     peerDependencies:
       '@tiptap/core': 3.22.5
       '@tiptap/pm': 3.22.5
 
+  '@tiptap/extension-node-range@3.24.0':
+    resolution: {integrity: sha512-JUrhuKD5raii6IsARETNq3seAXUB9UpQGjeSJKBKBOv10PBAq0RLKlI0lbv7t9FR4vfZE7is/XpvoZ0v2Vr9kw==}
+    peerDependencies:
+      '@tiptap/core': 3.24.0
+      '@tiptap/pm': 3.24.0
+
   '@tiptap/extension-ordered-list@3.22.5':
     resolution: {integrity: sha512-OXdh4k4CNrukwiSdWdEQ49uvgnqvR0Z9aNSP4HI5/kZQ/Te1NtRtYCpUrzWyO/7CtjcCisXHti0o9C/TV8YMbQ==}
     peerDependencies:
       '@tiptap/extension-list': 3.22.5
+
+  '@tiptap/extension-ordered-list@3.24.0':
+    resolution: {integrity: sha512-buRa6bmBDw0TztH+rAcusIye14DiLDS+yGheo6GiNCTD7kKJnksXagBdxvip3jhW5sx7gyAKvoBmvGSg1BbsGA==}
+    peerDependencies:
+      '@tiptap/extension-list': 3.24.0
 
   '@tiptap/extension-paragraph@3.22.5':
     resolution: {integrity: sha512-52KCto4+XKpnBWpIufspWLyq4UWxAWC72ANPdGuIhbi72NRTabiTbTVN40uwGSPkyakeESG0/vKdWJCVvB4f0g==}
     peerDependencies:
       '@tiptap/core': 3.22.5
 
+  '@tiptap/extension-paragraph@3.24.0':
+    resolution: {integrity: sha512-wD06aB6hO7LgcrlhGiw7I64k2tus9kNoICX5R+UecBSB1DVJdzKvXoXL2kPNv4DqYvljHdkIeK/OpuOTQd6MJA==}
+    peerDependencies:
+      '@tiptap/core': 3.24.0
+
   '@tiptap/extension-placeholder@3.22.5':
     resolution: {integrity: sha512-MZAohQ3FCS763BkhGXgaWRya6WruZjwRwEAkXP8vkxbERzl2OJRjniS4uXCWzAlRb3ttE103SnY7LMdM8FvsXw==}
     peerDependencies:
       '@tiptap/extensions': 3.22.5
+
+  '@tiptap/extension-placeholder@3.24.0':
+    resolution: {integrity: sha512-3jfYYCIuwMADhvZ92vB6c80YiTmgTSFR23JqyLps8qkQtV59Va5CBYpwJtSs1+VrbCVnNxhZBHhVXusZO3uRkA==}
+    peerDependencies:
+      '@tiptap/extensions': 3.24.0
 
   '@tiptap/extension-strike@3.22.5':
     resolution: {integrity: sha512-42WrrFK5gOom/0znH85x12Mw5IQ/6O6DWdyUWoRIrNA/qJpuHtU8oVU+bIgU2tuomMGHruRjIzgBQv5sBjEtww==}
     peerDependencies:
       '@tiptap/core': 3.22.5
 
+  '@tiptap/extension-strike@3.24.0':
+    resolution: {integrity: sha512-sfN1iQs6Fdlorrfe8wipDkTPwu/Egx3s2fkY7TAWusTGFHwlovuRUGFKqCL9dI4N3u6uqUMpEuWmQNgv+aQGjQ==}
+    peerDependencies:
+      '@tiptap/core': 3.24.0
+
   '@tiptap/extension-text@3.22.5':
     resolution: {integrity: sha512-bzpDOdAEo1JeoVZDIyV0oY0jGXkEG+AzF70SzHoRSjOvFDtKWunyXf9eO1OnOr2/fmMcckT2qwUBNBMQplWBzw==}
     peerDependencies:
       '@tiptap/core': 3.22.5
 
+  '@tiptap/extension-text@3.24.0':
+    resolution: {integrity: sha512-Im7keLPEihxm3+LyF+drYCoaOY5hlq35lvHAp/el6M8pJ/scts88HrYpdR1Yc4BtpZBIhfHSyWgPaupI4qwdeg==}
+    peerDependencies:
+      '@tiptap/core': 3.24.0
+
   '@tiptap/extension-underline@3.22.5':
     resolution: {integrity: sha512-9ut09rJD0iEbS6sk7yd2j6IwuFDLTNmDEGTDLodvqAfi+bq7ddsTDv0YviXoZaA9sdHAdTEVr2ITy2m6WK5jpA==}
     peerDependencies:
       '@tiptap/core': 3.22.5
+
+  '@tiptap/extension-underline@3.24.0':
+    resolution: {integrity: sha512-D4W4X3UMq9dLVIOfPB9+UodQ4eAJ8yDcm8qFWAwq0a15YWH6bnwulCuIdV+U5dEG+yaRxN8haB9GrrID9jmrSA==}
+    peerDependencies:
+      '@tiptap/core': 3.24.0
 
   '@tiptap/extensions@3.22.5':
     resolution: {integrity: sha512-Ifg4MzKCj3uRqe3ieTwYnomu2y4p7EXr2avVSKZYfh12i2dyWe2Gkn1KuZDREANVE+gHqFlQjJRYzhJFwzSCrg==}
@@ -3132,17 +3352,35 @@ packages:
       '@tiptap/core': 3.22.5
       '@tiptap/pm': 3.22.5
 
+  '@tiptap/extensions@3.24.0':
+    resolution: {integrity: sha512-z6gRYzy2ucJp07OQ0F2W07NxyhMTxPYH1ia2eGiQkWax1i56oExpjMsDHP8THWlg8Tb7NnbfKpkfh881EsmofA==}
+    peerDependencies:
+      '@tiptap/core': 3.24.0
+      '@tiptap/pm': 3.24.0
+
   '@tiptap/markdown@3.22.5':
     resolution: {integrity: sha512-lLuAySaY5EYNYLe7e4507B9yQMAEDJdOKy0g85UNFV8giorYLQx56aV2O94Qb9gv3egs5inkwVRNfeJzOWAwig==}
     peerDependencies:
       '@tiptap/core': 3.22.5
       '@tiptap/pm': 3.22.5
 
+  '@tiptap/markdown@3.24.0':
+    resolution: {integrity: sha512-EIEQmH8tOIWAxVnRpYSALIQCU8dVaGQoEVvmsa6B2B/zZeIsBSEZzcVVE2yGEVZtShf3ag37Szr6Lu7lTor3sw==}
+    peerDependencies:
+      '@tiptap/core': 3.24.0
+      '@tiptap/pm': 3.24.0
+
   '@tiptap/pm@3.22.5':
     resolution: {integrity: sha512-Cr9Mv4igxvI2tKMiahw48sZxva3PfDzypErH8IB82N+9qa9n9ygVMt0BOaDg53hLKxEEVeYr2S/wCcJIVFgBTw==}
 
+  '@tiptap/pm@3.24.0':
+    resolution: {integrity: sha512-QQP/78ryOZDN99gNBV7dgh69/8AYaOYQYFklq/iR+ZRFaaL3+qqHFvPVJapGkzPdymBgNJ34xjFM8n5pJ4QmMg==}
+
   '@tiptap/starter-kit@3.22.5':
     resolution: {integrity: sha512-LZ/LYbwH6rnDi5DnRyagkuNsYAVyhM+yJvvz+ZuYA0JkPiTXJV86J5PWSKew8M0gVfMHcNVtKjfQCvViFCeIgw==}
+
+  '@tiptap/starter-kit@3.24.0':
+    resolution: {integrity: sha512-Ef4PCP96vcY2GonXN9J0M8iC6zvxPTmQlL/QZiCwuYqqnH/hNpYIjNSQdTndiDpxRKofa32Sr2HWktgEnL32Bg==}
 
   '@tiptap/suggestion@3.22.5':
     resolution: {integrity: sha512-Uv79Ht/o4mx1GWIT65jeQTE67LMrA+K7d8p51XOe9PJw0H0fS3iCdeMJ8tAo3h6QrMJFejdsB7z8jJL9UbAnhA==}
@@ -3150,12 +3388,26 @@ packages:
       '@tiptap/core': 3.22.5
       '@tiptap/pm': 3.22.5
 
+  '@tiptap/suggestion@3.24.0':
+    resolution: {integrity: sha512-UlLIij1fxFy7tbCmqUoInWRijzsi8hsbaXKCx6L3KvLXtxHb4hMnDhd6W++rOk9Q1hDpmNf8qNIX498q/ZNstw==}
+    peerDependencies:
+      '@tiptap/core': 3.24.0
+      '@tiptap/pm': 3.24.0
+
   '@tiptap/vue-3@3.22.5':
     resolution: {integrity: sha512-xwSXPwDjauIVktMXBMaNaSgFyq3O1sXcX1vWyHyyCFlq4+8ekq4uXbjkD6y6IhZyr/AQoRYnjgosus+apGyGuA==}
     peerDependencies:
       '@floating-ui/dom': ^1.0.0
       '@tiptap/core': 3.22.5
       '@tiptap/pm': 3.22.5
+      vue: ^3.0.0
+
+  '@tiptap/vue-3@3.24.0':
+    resolution: {integrity: sha512-B7H630A5kGRHPrj60FMLbKC8EBWFvGeP8EytaKqxfByEFW6I2mYeZV4BzDptx6Hgy7h5oTXJ1yjc8DH1Q80WYA==}
+    peerDependencies:
+      '@floating-ui/dom': ^1.0.0
+      '@tiptap/core': 3.24.0
+      '@tiptap/pm': 3.24.0
       vue: ^3.0.0
 
   '@tiptap/y-tiptap@3.0.2':
@@ -3360,11 +3612,17 @@ packages:
   '@vue/compiler-core@3.5.34':
     resolution: {integrity: sha512-s9cLyK5mLcvZ4Agva5QgRsQyLKvts9WbU9DB6NqiZkkGEdwmcEiylj5Jbwkp680drF/NNCV8OlAJSe+yMLxaJw==}
 
+  '@vue/compiler-core@3.5.35':
+    resolution: {integrity: sha512-BUmHaR1J+O+CKZ9uJucdVTEr1LHsdyvv7vG3eNRhK3CczEHeMd/LtsHAuD7PbrxvI2envCY2v7HI1vC1aBRzKw==}
+
   '@vue/compiler-dom@3.5.33':
     resolution: {integrity: sha512-PXq0yrfCLzzL07rbXO4awtXY1Z06LG2eu6Adg3RJFa/j3Cii217XxxLXG22N330gw7GmALCY0Z8RgXEviwgpjA==}
 
   '@vue/compiler-dom@3.5.34':
     resolution: {integrity: sha512-EbF/T++k0e2MMZlJsBhzK8Sgwt0HcIPOhzn1CTB/lv6sQcyk+OWf8YeiLxZp3ro7MbbLcAfAJ6sEvjFWuNgUCw==}
+
+  '@vue/compiler-dom@3.5.35':
+    resolution: {integrity: sha512-k+bprkXxuqhVajgTx5mUHuir7TwQzUKOWR40ng1ncAqQRPnrLngGGgqVEEhOnTMlc8btHYVKmrP8s5Qyg0hvYA==}
 
   '@vue/compiler-sfc@3.5.33':
     resolution: {integrity: sha512-UTUvRO9cY+rROrx/pvN9P5Z7FgA6QGfokUCfhQE4EnmUj3rVnK+CHI0LsEO1pg+I7//iRYMUfcNcCPe7tg0CoA==}
@@ -3372,11 +3630,17 @@ packages:
   '@vue/compiler-sfc@3.5.34':
     resolution: {integrity: sha512-D/ihr6uZeIt6r+pVZf46RWT1fAsLFMbUP7k8G1VkiiWexriED9GrX3echHd4Abbt17zjlfiFJ8z7a3BxZOPNjg==}
 
+  '@vue/compiler-sfc@3.5.35':
+    resolution: {integrity: sha512-G5VPMcXTSywXBgtFOZOnHKBxKSrwXUcvY1iaF5/hRcy7t0J6CH/d8ha9F4nzi00Fax1eLV0QHM7v4mQu68jydw==}
+
   '@vue/compiler-ssr@3.5.33':
     resolution: {integrity: sha512-IErjYdnj1qIupG5xxiVIYiiRvDhGWV4zuh/RCrwfYpuL+HWQzeU6lCk/nF9r7olWMnjKxCAkOctT2qFWFkzb1A==}
 
   '@vue/compiler-ssr@3.5.34':
     resolution: {integrity: sha512-cDtTHKibkThKGHH1SP+WdccquNRYQDFH6rRjQCqT9G2ltFAfoR5pUftpab/z+aM5mW9HLLVQW7hfKKQe/1GBeQ==}
+
+  '@vue/compiler-ssr@3.5.35':
+    resolution: {integrity: sha512-rGhAeXgdM7/ffTJGXT69rCCdTmjDewnFuUZfBQQHTdcEBeWdT5HCGY60y2ytLJr9/Dsu7IntUi5z/w0h6Rjnzw==}
 
   '@vue/devtools-api@7.7.9':
     resolution: {integrity: sha512-kIE8wvwlcZ6TJTbNeU2HQNtaxLx3a84aotTITUuL/4bzfPxzajGBOoqjMhwZJ8L9qFYDU/lAYMEEm11dnZOD6g==}
@@ -3419,17 +3683,26 @@ packages:
   '@vue/reactivity@3.5.34':
     resolution: {integrity: sha512-y9XDjCEuBp+98k+UL5dbYkh57AHU4o6cxZedOPXw3bmrZZYLQsVHguGurq7hVrPCSrQtrnz1f9dssyFr+dMXfQ==}
 
+  '@vue/reactivity@3.5.35':
+    resolution: {integrity: sha512-tVc+SsHConvh/Lz64qq1pP3rYArBmK42xonovEcxY74SQtvctZodG/zhq54P5dr38cVuw25d27cPNRdlMidpGQ==}
+
   '@vue/runtime-core@3.5.33':
     resolution: {integrity: sha512-UpFF45RI9//a7rvq7RdOQblb4tup7hHG9QsmIrxkFQLzQ7R8/iNQ5LE15NhLZ1/WcHMU2b47u6P33CPUelHyIQ==}
 
   '@vue/runtime-core@3.5.34':
     resolution: {integrity: sha512-mKeBYvu8tcMSLhypAHBmriUFfWXKTCF/23Z4jiCoYK3UtWepkliViNLuR90V9XOyD62mUxs9p1jsrpK3CCGIzw==}
 
+  '@vue/runtime-core@3.5.35':
+    resolution: {integrity: sha512-A/xFNX9loIcWDygeQuNCfKuh0CoYBzxhqEMNah5TSFg9Z53DrFYEN2qi5CU9necjM1OWYegYREUTHmXTmhfXtg==}
+
   '@vue/runtime-dom@3.5.33':
     resolution: {integrity: sha512-IOxMsAOwquhfITgmOgaPYl7/j8gKUxUFoflRc+u4LxyD3+783xne8vNta1PONVCvCV9A0w7hkyEepINDqfO0tw==}
 
   '@vue/runtime-dom@3.5.34':
     resolution: {integrity: sha512-e8kZzERmCwUnBRVsgSQlAfrfU2rGoy0FFKPBXSlfEjc/O3KfA7QP0t1/2ZylrbchjmIKB4dPTd07A6WPr0eOrg==}
+
+  '@vue/runtime-dom@3.5.35':
+    resolution: {integrity: sha512-odrJ1C391dbGnyDRh8U+rnP7J2amIEzfmRk5vXy7xi3aZhEXofTvpi0T4HJb6jlNqQZTNPR5MPHSB3RHNkIORA==}
 
   '@vue/server-renderer@3.5.33':
     resolution: {integrity: sha512-0xylq/8/h44lVG0pZFknv1XIdEgymq2E9n59uTWJBG+dIgiT0TMCSsxrN7nO16Z0MU0MPjFcguBbZV8Itk52Hw==}
@@ -3441,11 +3714,19 @@ packages:
     peerDependencies:
       vue: 3.5.34
 
+  '@vue/server-renderer@3.5.35':
+    resolution: {integrity: sha512-NkebSOYdB97wi8OQcO3HqzZSlymJi/aWsN/7h74OSVhRTm6qGs3Jp3e0rCXynmWwSlKeRrnlIug+ilYoHBmQDA==}
+    peerDependencies:
+      vue: 3.5.35
+
   '@vue/shared@3.5.33':
     resolution: {integrity: sha512-5vR2QIlmaLG77Ygd4pMP6+SGQ5yox9VhtnbDWTy9DzMzdmeLxZ1QqxrywEZ9sa1AVubfIJyaCG3ytyWU81ufcQ==}
 
   '@vue/shared@3.5.34':
     resolution: {integrity: sha512-24uqU4OIiX29ryC3MeWid/Xf2fa2EFRUVLb77nRhk+UrTVrh/XiGtFAFmJBAtBRbjwNdsPRP+jj/OL27Eg1NDA==}
+
+  '@vue/shared@3.5.35':
+    resolution: {integrity: sha512-zSbjL7gRXwks2ZQLRGCajBtBXEOXW9Ddhn/HvSdrGkE2dqGnumzW8XtusRrxrE9LvqtiqDXQ+A60Hp6mvdYxfA==}
 
   '@vue/test-utils@2.4.10':
     resolution: {integrity: sha512-SmoZ5EA1kYiAFs9NkYdiFFQF+cSnUwnvlYEbY+DogWQZUiqOm/Y29eSbc5T6yi75SgSF9863SBeXniIEoPajCA==}
@@ -3742,8 +4023,8 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  better-auth@1.6.11:
-    resolution: {integrity: sha512-Wwt6+q07dwIhsp6XiM7L1qSXVUWBEtNl+eZvwM778CguFqDZFBN9Pt6LtFaHl55t8Z+Zc//5kxcbgDY8/79vFQ==}
+  better-auth@1.6.13:
+    resolution: {integrity: sha512-jn8ATnGWDzMwpO4a/3iyW1/RayOF/aoPQOfAeqyCVnQCdqkaONVas9CjbY6PovMsTMa/MG+GRABySfzqtj5J/g==}
     peerDependencies:
       '@lynx-js/react': '*'
       '@prisma/client': ^5.0.0 || ^6.0.0 || ^7.0.0
@@ -5044,8 +5325,11 @@ packages:
   linkifyjs@4.3.2:
     resolution: {integrity: sha512-NT1CJtq3hHIreOianA8aSXn6Cw0JzYOuDQbOrSPe7gqFnCpKP++MQe3ODgO3oh2GJFORkAAdqredOa60z63GbA==}
 
-  lint-staged@17.0.5:
-    resolution: {integrity: sha512-d12yC+/e8RhBjZtaxZn71FyrgU/P5e+uAPifhCLwdosQZP/zamSdKRWDC30ocVIbzDKiFG1McHc/LUgB92GIPw==}
+  linkifyjs@4.3.3:
+    resolution: {integrity: sha512-P8aEP5U/D1/IlTY2OeYsErdwh9bGuLE30NcXtKEjgdHcahveQoQwM2yZNsioQHsWFz0P7KKudisbrzCgR0sDHg==}
+
+  lint-staged@17.0.7:
+    resolution: {integrity: sha512-JrSobt+tW3rH8IOMi8tDZd3foorM5yPEkLD/V2NxobgHrFfHWGee4MOLVuZeScgxftEwbHrPHIFA/ZL+nUJeuA==}
     engines: {node: '>=22.22.1'}
     hasBin: true
 
@@ -5063,6 +5347,10 @@ packages:
 
   local-pkg@1.1.2:
     resolution: {integrity: sha512-arhlxbFRmoQHl33a0Zkle/YWlmNwoyt6QNZEIJcqNbdrsix5Lvc4HyyI3EnwxTYlZYc32EbYrQ8SzEZ7dqgg9A==}
+    engines: {node: '>=14'}
+
+  local-pkg@1.2.1:
+    resolution: {integrity: sha512-++gUqRDEvcnN6Zhqrr+y/CkVEHhlrR96vZn3nZZPYzMcBUyBtTKzB9NadClFIsIVSsu+3i9tfk/erqy9kAmt7Q==}
     engines: {node: '>=14'}
 
   locate-path@5.0.0:
@@ -5283,9 +5571,6 @@ packages:
   motion-dom@12.38.0:
     resolution: {integrity: sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA==}
 
-  motion-utils@12.29.2:
-    resolution: {integrity: sha512-G3kc34H2cX2gI63RqU+cZq+zWRRPSsNIOjpdl9TN4AQwC4sgwYPl/Q/Obf/d53nOm569T0fYK+tcoSV50BWx8A==}
-
   motion-utils@12.36.0:
     resolution: {integrity: sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==}
 
@@ -5313,6 +5598,11 @@ packages:
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -5909,6 +6199,10 @@ packages:
     resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  postcss@8.5.15:
+    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+    engines: {node: ^10 || ^12 || >=14}
+
   powershell-utils@0.1.0:
     resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==}
     engines: {node: '>=20'}
@@ -5944,6 +6238,9 @@ packages:
 
   prosemirror-history@1.5.0:
     resolution: {integrity: sha512-zlzTiH01eKA55UAf1MEjtssJeHnGxO0j4K4Dpx+gnmX9n+SHNlDqI2oO1Kv1iPN5B1dm5fsljCfqKF9nFL6HRg==}
+
+  prosemirror-inputrules@1.5.1:
+    resolution: {integrity: sha512-7wj4uMjKaXWAQ1CDgxNzNtR9AlsuwzHfdFH1ygEHA2KHF2DOEaXl1CJfNPAKCg9qNEh4rum975QLaCiQPyY6Fw==}
 
   prosemirror-keymap@1.2.3:
     resolution: {integrity: sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw==}
@@ -6060,6 +6357,11 @@ packages:
 
   reka-ui@2.9.7:
     resolution: {integrity: sha512-aX7foYYR20v4+majO58OJJdBNfLMm0eJb448l9N4JVy8JB7GXOr4H/S4a+J1pkcoxZH8Cb7YHpJ855+miAm7sA==}
+    peerDependencies:
+      vue: '>= 3.4.0'
+
+  reka-ui@2.9.8:
+    resolution: {integrity: sha512-7dxaBJ6nQ0zOQZXPV45219tTEgZPstmihBLS9ABPhSiPiJ8SiF0sacfZHFaBptS0v9N4tzsevq+8MNBpE4p5JQ==}
     peerDependencies:
       vue: '>= 3.4.0'
 
@@ -6464,6 +6766,10 @@ packages:
     resolution: {integrity: sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==}
     engines: {node: '>=18'}
 
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
@@ -6657,6 +6963,16 @@ packages:
       '@nuxt/kit':
         optional: true
 
+  unplugin-vue-components@32.1.0:
+    resolution: {integrity: sha512-YiUkSxuRjab18XFOrX5VsIxXzccrfmHVGsGeJgSgklb829DQmCy9E4vvDUE4tuvZZdxyFJZX0Oc4TPnnxiiMyg==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@nuxt/kit': ^3.2.2 || ^4.0.0
+      vue: ^3.0.0
+    peerDependenciesMeta:
+      '@nuxt/kit':
+        optional: true
+
   unplugin@2.3.11:
     resolution: {integrity: sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==}
     engines: {node: '>=18.12.0'}
@@ -6821,8 +7137,8 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
-  valibot@1.4.0:
-    resolution: {integrity: sha512-iC/x7fVcSyOwlm/VSt7RlHnzNGLGvR9GnxdifUeWoCJo0q4ZZvrVkIHC6faTlkxG47I2Y4UrFquPuVHCrOnrLg==}
+  valibot@1.4.1:
+    resolution: {integrity: sha512-klCmFTz2jeDluy9RwX+F884TCiogtdBJ/YaxSx1EOBYXa3NXNWj8kR1jjN8rzluwojJVWWaHJ4r1U5LfICnM3g==}
     peerDependencies:
       typescript: '>=5'
     peerDependenciesMeta:
@@ -7093,6 +7409,14 @@ packages:
       typescript:
         optional: true
 
+  vue@3.5.35:
+    resolution: {integrity: sha512-cx89fnr+0kVGHiNFG6y6s0bdjypJRFNZn6x3WPstNdQR1bi1mbB7h4v5IBGTsPJU3nK1+0Iqj3Zf+hZWMieR4Q==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   w3c-keyname@2.2.8:
     resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
 
@@ -7213,8 +7537,8 @@ packages:
     engines: {node: '>= 14.6'}
     hasBin: true
 
-  yaml@2.8.4:
-    resolution: {integrity: sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==}
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
     engines: {node: '>= 14.6'}
     hasBin: true
 
@@ -7438,10 +7762,6 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
-  '@babel/parser@7.29.2':
-    dependencies:
-      '@babel/types': 7.29.0
-
   '@babel/parser@7.29.3':
     dependencies:
       '@babel/types': 7.29.0
@@ -7499,9 +7819,9 @@ snapshots:
       '@babel/helper-string-parser': 8.0.0-rc.5
       '@babel/helper-validator-identifier': 8.0.0-rc.5
 
-  '@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.1.1)':
+  '@better-auth/core@1.6.13(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.1.1)':
     dependencies:
-      '@better-auth/utils': 0.4.0
+      '@better-auth/utils': 0.4.1
       '@better-fetch/fetch': 1.1.21
       '@opentelemetry/semantic-conventions': 1.40.0
       '@standard-schema/spec': 1.1.0
@@ -7511,54 +7831,58 @@ snapshots:
       nanostores: 1.1.1
       zod: 4.3.6
 
-  '@better-auth/drizzle-adapter@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.1.1))(@better-auth/utils@0.4.0)':
+  '@better-auth/drizzle-adapter@1.6.13(@better-auth/core@1.6.13(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.1.1))(@better-auth/utils@0.4.1)':
     dependencies:
-      '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.1.1)
-      '@better-auth/utils': 0.4.0
+      '@better-auth/core': 1.6.13(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.1.1)
+      '@better-auth/utils': 0.4.1
 
-  '@better-auth/kysely-adapter@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.1.1))(@better-auth/utils@0.4.0)(kysely@0.28.17)':
+  '@better-auth/kysely-adapter@1.6.13(@better-auth/core@1.6.13(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.1.1))(@better-auth/utils@0.4.1)(kysely@0.28.17)':
     dependencies:
-      '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.1.1)
-      '@better-auth/utils': 0.4.0
+      '@better-auth/core': 1.6.13(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.1.1)
+      '@better-auth/utils': 0.4.1
     optionalDependencies:
       kysely: 0.28.17
 
-  '@better-auth/memory-adapter@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.1.1))(@better-auth/utils@0.4.0)':
+  '@better-auth/memory-adapter@1.6.13(@better-auth/core@1.6.13(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.1.1))(@better-auth/utils@0.4.1)':
     dependencies:
-      '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.1.1)
-      '@better-auth/utils': 0.4.0
+      '@better-auth/core': 1.6.13(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.1.1)
+      '@better-auth/utils': 0.4.1
 
-  '@better-auth/mongo-adapter@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.1.1))(@better-auth/utils@0.4.0)(mongodb@7.2.0)':
+  '@better-auth/mongo-adapter@1.6.13(@better-auth/core@1.6.13(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.1.1))(@better-auth/utils@0.4.1)(mongodb@7.2.0)':
     dependencies:
-      '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.1.1)
-      '@better-auth/utils': 0.4.0
+      '@better-auth/core': 1.6.13(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.1.1)
+      '@better-auth/utils': 0.4.1
     optionalDependencies:
       mongodb: 7.2.0
 
-  '@better-auth/passkey@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.1.1))(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-auth@1.6.11(mongodb@7.2.0)(vitest@4.1.7(@types/node@25.9.1)(happy-dom@20.9.0)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3)))(vue@3.5.33(typescript@6.0.3)))(better-call@1.3.5(zod@4.3.6))(nanostores@1.1.1)':
+  '@better-auth/passkey@1.6.13(@better-auth/core@1.6.13(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.1.1))(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(better-auth@1.6.13(mongodb@7.2.0)(vitest@4.1.7(@types/node@25.9.1)(happy-dom@20.9.0)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3)))(vue@3.5.35(typescript@6.0.3)))(better-call@1.3.5(zod@4.3.6))(nanostores@1.1.1)':
     dependencies:
-      '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.1.1)
-      '@better-auth/utils': 0.4.0
+      '@better-auth/core': 1.6.13(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.1.1)
+      '@better-auth/utils': 0.4.1
       '@better-fetch/fetch': 1.1.21
       '@simplewebauthn/browser': 13.2.2
       '@simplewebauthn/server': 13.2.3
-      better-auth: 1.6.11(mongodb@7.2.0)(vitest@4.1.7(@types/node@25.9.1)(happy-dom@20.9.0)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3)))(vue@3.5.33(typescript@6.0.3))
+      better-auth: 1.6.13(mongodb@7.2.0)(vitest@4.1.7(@types/node@25.9.1)(happy-dom@20.9.0)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3)))(vue@3.5.35(typescript@6.0.3))
       better-call: 1.3.5(zod@4.3.6)
       nanostores: 1.1.1
       zod: 4.3.6
 
-  '@better-auth/prisma-adapter@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.1.1))(@better-auth/utils@0.4.0)':
+  '@better-auth/prisma-adapter@1.6.13(@better-auth/core@1.6.13(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.1.1))(@better-auth/utils@0.4.1)':
     dependencies:
-      '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.1.1)
-      '@better-auth/utils': 0.4.0
+      '@better-auth/core': 1.6.13(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.1.1)
+      '@better-auth/utils': 0.4.1
 
-  '@better-auth/telemetry@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.1.1))(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)':
+  '@better-auth/telemetry@1.6.13(@better-auth/core@1.6.13(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.1.1))(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)':
     dependencies:
-      '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.1.1)
-      '@better-auth/utils': 0.4.0
+      '@better-auth/core': 1.6.13(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.1.1)
+      '@better-auth/utils': 0.4.1
       '@better-fetch/fetch': 1.1.21
 
   '@better-auth/utils@0.4.0':
+    dependencies:
+      '@noble/hashes': 2.0.1
+
+  '@better-auth/utils@0.4.1':
     dependencies:
       '@noble/hashes': 2.0.1
 
@@ -7905,18 +8229,18 @@ snapshots:
 
   '@floating-ui/utils@0.2.11': {}
 
-  '@floating-ui/vue@1.1.10(vue@3.5.33(typescript@6.0.3))':
+  '@floating-ui/vue@1.1.10(vue@3.5.35(typescript@6.0.3))':
     dependencies:
       '@floating-ui/dom': 1.7.6
       '@floating-ui/utils': 0.2.11
-      vue-demi: 0.14.10(vue@3.5.33(typescript@6.0.3))
+      vue-demi: 0.14.10(vue@3.5.35(typescript@6.0.3))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
 
   '@hexagon/base64@1.1.28': {}
 
-  '@hey-api/codegen-core@0.8.1(magicast@0.5.2)':
+  '@hey-api/codegen-core@0.8.2(magicast@0.5.2)':
     dependencies:
       '@hey-api/types': 0.1.4
       ansi-colors: 4.1.3
@@ -7931,11 +8255,11 @@ snapshots:
       '@types/json-schema': 7.0.15
       js-yaml: 4.1.1
 
-  '@hey-api/openapi-ts@0.97.2(magicast@0.5.2)(typescript@6.0.3)':
+  '@hey-api/openapi-ts@0.97.3(magicast@0.5.2)(typescript@6.0.3)':
     dependencies:
-      '@hey-api/codegen-core': 0.8.1(magicast@0.5.2)
+      '@hey-api/codegen-core': 0.8.2(magicast@0.5.2)
       '@hey-api/json-schema-ref-parser': 1.4.2
-      '@hey-api/shared': 0.4.4(magicast@0.5.2)
+      '@hey-api/shared': 0.4.5(magicast@0.5.2)
       '@hey-api/spec-types': 0.2.0
       '@hey-api/types': 0.1.4
       '@lukeed/ms': 2.0.2
@@ -7947,9 +8271,9 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@hey-api/shared@0.4.4(magicast@0.5.2)':
+  '@hey-api/shared@0.4.5(magicast@0.5.2)':
     dependencies:
-      '@hey-api/codegen-core': 0.8.1(magicast@0.5.2)
+      '@hey-api/codegen-core': 0.8.2(magicast@0.5.2)
       '@hey-api/json-schema-ref-parser': 1.4.2
       '@hey-api/spec-types': 0.2.0
       '@hey-api/types': 0.1.4
@@ -7966,7 +8290,7 @@ snapshots:
 
   '@hey-api/types@0.1.4': {}
 
-  '@iconify-json/lucide@1.2.109':
+  '@iconify-json/lucide@1.2.111':
     dependencies:
       '@iconify/types': 2.0.0
 
@@ -7992,15 +8316,15 @@ snapshots:
       '@iconify/types': 2.0.0
       import-meta-resolve: 4.2.0
 
-  '@iconify/vue@5.0.0(vue@3.5.33(typescript@6.0.3))':
+  '@iconify/vue@5.0.0(vue@3.5.35(typescript@6.0.3))':
     dependencies:
       '@iconify/types': 2.0.0
-      vue: 3.5.33(typescript@6.0.3)
+      vue: 3.5.35(typescript@6.0.3)
 
-  '@iconify/vue@5.0.1(vue@3.5.33(typescript@6.0.3))':
+  '@iconify/vue@5.0.1(vue@3.5.35(typescript@6.0.3))':
     dependencies:
       '@iconify/types': 2.0.0
-      vue: 3.5.33(typescript@6.0.3)
+      vue: 3.5.35(typescript@6.0.3)
 
   '@img/colour@1.0.0':
     optional: true
@@ -8082,10 +8406,10 @@ snapshots:
 
   '@kwsites/promise-deferred@1.1.1': {}
 
-  '@lenne.tech/bug.lt@1.6.5(@babel/parser@7.29.3)(db0@0.3.4)(embla-carousel@8.6.0)(ioredis@5.10.1)(magicast@0.5.2)(qrcode@1.5.4)(typescript@6.0.3)(valibot@1.4.0(typescript@6.0.3))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.33(typescript@6.0.3))':
+  '@lenne.tech/bug.lt@1.6.5(@babel/parser@7.29.3)(db0@0.3.4)(embla-carousel@8.6.0)(ioredis@5.10.1)(magicast@0.5.2)(qrcode@1.5.4)(typescript@6.0.3)(valibot@1.4.1(typescript@6.0.3))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.35(typescript@6.0.3))':
     dependencies:
       '@nuxt/kit': 4.2.1(magicast@0.5.2)
-      '@nuxt/ui': 4.2.1(@babel/parser@7.29.3)(db0@0.3.4)(embla-carousel@8.6.0)(ioredis@5.10.1)(magicast@0.5.2)(qrcode@1.5.4)(typescript@6.0.3)(valibot@1.4.0(typescript@6.0.3))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.33(typescript@6.0.3))(zod@4.1.13)
+      '@nuxt/ui': 4.2.1(@babel/parser@7.29.3)(db0@0.3.4)(embla-carousel@8.6.0)(ioredis@5.10.1)(magicast@0.5.2)(qrcode@1.5.4)(typescript@6.0.3)(valibot@1.4.1(typescript@6.0.3))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.35(typescript@6.0.3))(zod@4.1.13)
       modern-screenshot: 4.6.7
       zod: 4.1.13
     transitivePeerDependencies:
@@ -8137,13 +8461,13 @@ snapshots:
       - vue-router
       - yup
 
-  '@lenne.tech/nuxt-extensions@1.6.0(64c77fc7986b0151ab228ee70fc2833c)':
+  '@lenne.tech/nuxt-extensions@1.7.1(dc7c69ad612f89fa79dd9b9ed5300da1)':
     dependencies:
-      '@nuxt/kit': 4.4.4(magicast@0.5.2)
-      better-auth: 1.6.11(mongodb@7.2.0)(vitest@4.1.7(@types/node@25.9.1)(happy-dom@20.9.0)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3)))(vue@3.5.33(typescript@6.0.3))
-      nuxt: 4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(oxlint@1.43.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.33(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3)
+      '@nuxt/kit': 4.4.6(magicast@0.5.2)
+      better-auth: 1.6.13(mongodb@7.2.0)(vitest@4.1.7(@types/node@25.9.1)(happy-dom@20.9.0)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3)))(vue@3.5.35(typescript@6.0.3))
+      nuxt: 4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(oxlint@1.43.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3)
     optionalDependencies:
-      '@better-auth/passkey': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.1.1))(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-auth@1.6.11(mongodb@7.2.0)(vitest@4.1.7(@types/node@25.9.1)(happy-dom@20.9.0)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3)))(vue@3.5.33(typescript@6.0.3)))(better-call@1.3.5(zod@4.3.6))(nanostores@1.1.1)
+      '@better-auth/passkey': 1.6.13(@better-auth/core@1.6.13(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.1.1))(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(better-auth@1.6.13(mongodb@7.2.0)(vitest@4.1.7(@types/node@25.9.1)(happy-dom@20.9.0)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3)))(vue@3.5.35(typescript@6.0.3)))(better-call@1.3.5(zod@4.3.6))(nanostores@1.1.1)
       '@playwright/test': 1.60.0
       tus-js-client: 4.3.1
     transitivePeerDependencies:
@@ -8252,7 +8576,7 @@ snapshots:
 
   '@nuxt/devtools-kit@3.1.1(magicast@0.5.2)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))':
     dependencies:
-      '@nuxt/kit': 4.4.4(magicast@0.5.2)
+      '@nuxt/kit': 4.4.6(magicast@0.5.2)
       execa: 8.0.1
       vite: 7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3)
     transitivePeerDependencies:
@@ -8268,8 +8592,8 @@ snapshots:
 
   '@nuxt/devtools-kit@4.0.0-alpha.3(magicast@0.5.2)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))':
     dependencies:
-      '@nuxt/kit': 4.4.2(magicast@0.5.2)
-      tinyexec: 1.1.1
+      '@nuxt/kit': 4.4.6(magicast@0.5.2)
+      tinyexec: 1.1.2
       vite: 7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - magicast
@@ -8284,47 +8608,6 @@ snapshots:
       pathe: 2.0.3
       pkg-types: 2.3.0
       semver: 7.7.4
-
-  '@nuxt/devtools@3.2.4(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.33(typescript@6.0.3))':
-    dependencies:
-      '@nuxt/devtools-kit': 3.2.4(magicast@0.5.2)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))
-      '@nuxt/devtools-wizard': 3.2.4
-      '@nuxt/kit': 4.4.2(magicast@0.5.2)
-      '@vue/devtools-core': 8.1.1(vue@3.5.33(typescript@6.0.3))
-      '@vue/devtools-kit': 8.1.0
-      birpc: 4.0.0
-      consola: 3.4.2
-      destr: 2.0.5
-      error-stack-parser-es: 1.0.5
-      execa: 8.0.1
-      fast-npm-meta: 1.4.2
-      get-port-please: 3.2.0
-      hookable: 6.1.0
-      image-meta: 0.2.2
-      is-installed-globally: 1.0.0
-      launch-editor: 2.13.1
-      local-pkg: 1.1.2
-      magicast: 0.5.2
-      nypm: 0.6.5
-      ohash: 2.0.11
-      pathe: 2.0.3
-      perfect-debounce: 2.1.0
-      pkg-types: 2.3.0
-      semver: 7.7.4
-      simple-git: 3.36.0
-      sirv: 3.0.2
-      structured-clone-es: 2.0.0
-      tinyglobby: 0.2.15
-      vite: 7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3)
-      vite-plugin-inspect: 11.3.3(@nuxt/kit@4.4.2(magicast@0.5.2))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))
-      vite-plugin-vue-tracer: 1.3.0(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.33(typescript@6.0.3))
-      which: 6.0.1
-      ws: 8.21.0
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - vue
 
   '@nuxt/devtools@3.2.4(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.34(typescript@6.0.3))':
     dependencies:
@@ -8367,10 +8650,51 @@ snapshots:
       - utf-8-validate
       - vue
 
+  '@nuxt/devtools@3.2.4(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.35(typescript@6.0.3))':
+    dependencies:
+      '@nuxt/devtools-kit': 3.2.4(magicast@0.5.2)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))
+      '@nuxt/devtools-wizard': 3.2.4
+      '@nuxt/kit': 4.4.2(magicast@0.5.2)
+      '@vue/devtools-core': 8.1.1(vue@3.5.35(typescript@6.0.3))
+      '@vue/devtools-kit': 8.1.0
+      birpc: 4.0.0
+      consola: 3.4.2
+      destr: 2.0.5
+      error-stack-parser-es: 1.0.5
+      execa: 8.0.1
+      fast-npm-meta: 1.4.2
+      get-port-please: 3.2.0
+      hookable: 6.1.0
+      image-meta: 0.2.2
+      is-installed-globally: 1.0.0
+      launch-editor: 2.13.1
+      local-pkg: 1.1.2
+      magicast: 0.5.2
+      nypm: 0.6.5
+      ohash: 2.0.11
+      pathe: 2.0.3
+      perfect-debounce: 2.1.0
+      pkg-types: 2.3.0
+      semver: 7.7.4
+      simple-git: 3.36.0
+      sirv: 3.0.2
+      structured-clone-es: 2.0.0
+      tinyglobby: 0.2.15
+      vite: 7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3)
+      vite-plugin-inspect: 11.3.3(@nuxt/kit@4.4.2(magicast@0.5.2))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))
+      vite-plugin-vue-tracer: 1.3.0(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.35(typescript@6.0.3))
+      which: 6.0.1
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - vue
+
   '@nuxt/fonts@0.12.1(db0@0.3.4)(ioredis@5.10.1)(magicast@0.5.2)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))':
     dependencies:
       '@nuxt/devtools-kit': 3.1.1(magicast@0.5.2)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))
-      '@nuxt/kit': 4.4.4(magicast@0.5.2)
+      '@nuxt/kit': 4.4.6(magicast@0.5.2)
       consola: 3.4.2
       css-tree: 3.2.1
       defu: 6.1.7
@@ -8378,7 +8702,7 @@ snapshots:
       fontaine: 0.7.0
       fontless: 0.1.0(db0@0.3.4)(ioredis@5.10.1)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))
       h3: 1.15.11
-      jiti: 2.6.1
+      jiti: 2.7.0
       magic-regexp: 0.10.0
       magic-string: 0.30.21
       node-fetch-native: 1.6.7
@@ -8453,14 +8777,14 @@ snapshots:
       - uploadthing
       - vite
 
-  '@nuxt/icon@2.2.1(magicast@0.5.2)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.33(typescript@6.0.3))':
+  '@nuxt/icon@2.2.1(magicast@0.5.2)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.35(typescript@6.0.3))':
     dependencies:
       '@iconify/collections': 1.0.648
       '@iconify/types': 2.0.0
       '@iconify/utils': 3.1.0
-      '@iconify/vue': 5.0.0(vue@3.5.33(typescript@6.0.3))
+      '@iconify/vue': 5.0.1(vue@3.5.35(typescript@6.0.3))
       '@nuxt/devtools-kit': 3.2.4(magicast@0.5.2)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))
-      '@nuxt/kit': 4.4.4(magicast@0.5.2)
+      '@nuxt/kit': 4.4.6(magicast@0.5.2)
       consola: 3.4.2
       local-pkg: 1.1.2
       mlly: 1.8.2
@@ -8474,12 +8798,12 @@ snapshots:
       - vite
       - vue
 
-  '@nuxt/icon@2.2.2(magicast@0.5.2)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.33(typescript@6.0.3))':
+  '@nuxt/icon@2.2.2(magicast@0.5.2)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.35(typescript@6.0.3))':
     dependencies:
       '@iconify/collections': 1.0.688
       '@iconify/types': 2.0.0
       '@iconify/utils': 3.1.3
-      '@iconify/vue': 5.0.1(vue@3.5.33(typescript@6.0.3))
+      '@iconify/vue': 5.0.1(vue@3.5.35(typescript@6.0.3))
       '@nuxt/devtools-kit': 3.2.4(magicast@0.5.2)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))
       '@nuxt/kit': 4.4.6(magicast@0.5.2)
       consola: 3.4.2
@@ -8641,7 +8965,7 @@ snapshots:
       errx: 0.1.0
       exsolve: 1.0.8
       ignore: 7.0.5
-      jiti: 2.6.1
+      jiti: 2.7.0
       klona: 2.0.6
       mlly: 1.8.2
       ohash: 2.0.11
@@ -8649,7 +8973,7 @@ snapshots:
       pkg-types: 2.3.1
       rc9: 3.0.1
       scule: 1.3.0
-      semver: 7.7.4
+      semver: 7.8.1
       tinyglobby: 0.2.16
       ufo: 1.6.4
       unctx: 2.5.0
@@ -8682,7 +9006,7 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/nitro-server@4.4.6(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(db0@0.3.4)(ioredis@5.10.1)(magicast@0.5.2)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(oxlint@1.43.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.33(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3))(oxc-parser@0.131.0)(typescript@6.0.3)':
+  '@nuxt/nitro-server@4.4.6(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(db0@0.3.4)(ioredis@5.10.1)(magicast@0.5.2)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(oxlint@1.43.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3))(oxc-parser@0.131.0)(typescript@6.0.3)':
     dependencies:
       '@nuxt/devalue': 2.0.2
       '@nuxt/kit': 4.4.6(magicast@0.5.2)
@@ -8700,7 +9024,7 @@ snapshots:
       klona: 2.0.6
       mocked-exports: 0.1.1
       nitropack: 2.13.4(oxc-parser@0.131.0)
-      nuxt: 4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(oxlint@1.43.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.33(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3)
+      nuxt: 4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(oxlint@1.43.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3)
       nypm: 0.6.6
       ohash: 2.0.11
       pathe: 2.0.3
@@ -8775,7 +9099,7 @@ snapshots:
       rc9: 3.0.1
       std-env: 4.1.0
 
-  '@nuxt/test-utils@4.0.3(@playwright/test@1.60.0)(@vue/test-utils@2.4.10(@vue/compiler-dom@3.5.34)(@vue/server-renderer@3.5.34(vue@3.5.33(typescript@6.0.3)))(vue@3.5.33(typescript@6.0.3)))(happy-dom@20.9.0)(magicast@0.5.2)(playwright-core@1.60.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vitest@4.1.7(@types/node@25.9.1)(happy-dom@20.9.0)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3)))':
+  '@nuxt/test-utils@4.0.3(@playwright/test@1.60.0)(@vue/test-utils@2.4.10(@vue/compiler-dom@3.5.35)(@vue/server-renderer@3.5.35(vue@3.5.35(typescript@6.0.3)))(vue@3.5.35(typescript@6.0.3)))(happy-dom@20.9.0)(magicast@0.5.2)(playwright-core@1.60.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vitest@4.1.7(@types/node@25.9.1)(happy-dom@20.9.0)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3)))':
     dependencies:
       '@clack/prompts': 1.2.0
       '@nuxt/devtools-kit': 2.7.0(magicast@0.5.2)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))
@@ -8804,11 +9128,11 @@ snapshots:
       tinyexec: 1.1.1
       ufo: 1.6.3
       unplugin: 3.0.0
-      vitest-environment-nuxt: 2.0.0(@playwright/test@1.60.0)(@vue/test-utils@2.4.10(@vue/compiler-dom@3.5.34)(@vue/server-renderer@3.5.34(vue@3.5.33(typescript@6.0.3)))(vue@3.5.33(typescript@6.0.3)))(happy-dom@20.9.0)(magicast@0.5.2)(playwright-core@1.60.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vitest@4.1.7(@types/node@25.9.1)(happy-dom@20.9.0)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3)))
+      vitest-environment-nuxt: 2.0.0(@playwright/test@1.60.0)(@vue/test-utils@2.4.10(@vue/compiler-dom@3.5.35)(@vue/server-renderer@3.5.35(vue@3.5.35(typescript@6.0.3)))(vue@3.5.35(typescript@6.0.3)))(happy-dom@20.9.0)(magicast@0.5.2)(playwright-core@1.60.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vitest@4.1.7(@types/node@25.9.1)(happy-dom@20.9.0)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3)))
       vue: 3.5.33(typescript@6.0.3)
     optionalDependencies:
       '@playwright/test': 1.60.0
-      '@vue/test-utils': 2.4.10(@vue/compiler-dom@3.5.34)(@vue/server-renderer@3.5.34(vue@3.5.33(typescript@6.0.3)))(vue@3.5.33(typescript@6.0.3))
+      '@vue/test-utils': 2.4.10(@vue/compiler-dom@3.5.35)(@vue/server-renderer@3.5.35(vue@3.5.35(typescript@6.0.3)))(vue@3.5.35(typescript@6.0.3))
       happy-dom: 20.9.0
       playwright-core: 1.60.0
       vitest: 4.1.7(@types/node@25.9.1)(happy-dom@20.9.0)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))
@@ -8818,24 +9142,24 @@ snapshots:
       - typescript
       - vite
 
-  '@nuxt/ui@4.2.1(@babel/parser@7.29.3)(db0@0.3.4)(embla-carousel@8.6.0)(ioredis@5.10.1)(magicast@0.5.2)(qrcode@1.5.4)(typescript@6.0.3)(valibot@1.4.0(typescript@6.0.3))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.33(typescript@6.0.3))(zod@4.1.13)':
+  '@nuxt/ui@4.2.1(@babel/parser@7.29.3)(db0@0.3.4)(embla-carousel@8.6.0)(ioredis@5.10.1)(magicast@0.5.2)(qrcode@1.5.4)(typescript@6.0.3)(valibot@1.4.1(typescript@6.0.3))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.35(typescript@6.0.3))(zod@4.1.13)':
     dependencies:
-      '@iconify/vue': 5.0.0(vue@3.5.33(typescript@6.0.3))
+      '@iconify/vue': 5.0.0(vue@3.5.35(typescript@6.0.3))
       '@internationalized/date': 3.11.0
       '@internationalized/number': 3.6.5
       '@nuxt/fonts': 0.12.1(db0@0.3.4)(ioredis@5.10.1)(magicast@0.5.2)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))
-      '@nuxt/icon': 2.2.1(magicast@0.5.2)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.33(typescript@6.0.3))
-      '@nuxt/kit': 4.4.4(magicast@0.5.2)
+      '@nuxt/icon': 2.2.1(magicast@0.5.2)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.35(typescript@6.0.3))
+      '@nuxt/kit': 4.4.6(magicast@0.5.2)
       '@nuxt/schema': 4.4.4
       '@nuxtjs/color-mode': 3.5.2(magicast@0.5.2)
       '@standard-schema/spec': 1.1.0
       '@tailwindcss/postcss': 4.1.18
       '@tailwindcss/vite': 4.3.0(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))
-      '@tanstack/vue-table': 8.21.3(vue@3.5.33(typescript@6.0.3))
-      '@tanstack/vue-virtual': 3.13.18(vue@3.5.33(typescript@6.0.3))
-      '@unhead/vue': 2.1.13(vue@3.5.33(typescript@6.0.3))
-      '@vueuse/core': 13.9.0(vue@3.5.33(typescript@6.0.3))
-      '@vueuse/integrations': 13.9.0(fuse.js@7.1.0)(qrcode@1.5.4)(vue@3.5.33(typescript@6.0.3))
+      '@tanstack/vue-table': 8.21.3(vue@3.5.35(typescript@6.0.3))
+      '@tanstack/vue-virtual': 3.13.18(vue@3.5.35(typescript@6.0.3))
+      '@unhead/vue': 2.1.13(vue@3.5.35(typescript@6.0.3))
+      '@vueuse/core': 13.9.0(vue@3.5.35(typescript@6.0.3))
+      '@vueuse/integrations': 13.9.0(fuse.js@7.1.0)(qrcode@1.5.4)(vue@3.5.35(typescript@6.0.3))
       colortranslator: 5.0.0
       consola: 3.4.2
       defu: 6.1.7
@@ -8844,17 +9168,17 @@ snapshots:
       embla-carousel-autoplay: 8.6.0(embla-carousel@8.6.0)
       embla-carousel-class-names: 8.6.0(embla-carousel@8.6.0)
       embla-carousel-fade: 8.6.0(embla-carousel@8.6.0)
-      embla-carousel-vue: 8.6.0(vue@3.5.33(typescript@6.0.3))
+      embla-carousel-vue: 8.6.0(vue@3.5.35(typescript@6.0.3))
       embla-carousel-wheel-gestures: 8.1.0(embla-carousel@8.6.0)
       fuse.js: 7.1.0
       hookable: 5.5.3
       knitwork: 1.3.0
       magic-string: 0.30.21
       mlly: 1.8.2
-      motion-v: 1.10.2(@vueuse/core@13.9.0(vue@3.5.33(typescript@6.0.3)))(vue@3.5.33(typescript@6.0.3))
+      motion-v: 1.10.2(@vueuse/core@13.9.0(vue@3.5.35(typescript@6.0.3)))(vue@3.5.35(typescript@6.0.3))
       ohash: 2.0.11
       pathe: 2.0.3
-      reka-ui: 2.6.0(typescript@6.0.3)(vue@3.5.33(typescript@6.0.3))
+      reka-ui: 2.6.0(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3))
       scule: 1.3.0
       tailwind-merge: 3.4.0
       tailwind-variants: 3.2.2(tailwind-merge@3.4.0)(tailwindcss@4.3.0)
@@ -8862,12 +9186,12 @@ snapshots:
       tinyglobby: 0.2.16
       typescript: 6.0.3
       unplugin: 2.3.11
-      unplugin-auto-import: 20.3.0(@nuxt/kit@4.4.4(magicast@0.5.2))(@vueuse/core@13.9.0(vue@3.5.33(typescript@6.0.3)))
-      unplugin-vue-components: 30.0.0(@babel/parser@7.29.3)(@nuxt/kit@4.4.4(magicast@0.5.2))(vue@3.5.33(typescript@6.0.3))
-      vaul-vue: 0.4.1(reka-ui@2.6.0(typescript@6.0.3)(vue@3.5.33(typescript@6.0.3)))(vue@3.5.33(typescript@6.0.3))
+      unplugin-auto-import: 20.3.0(@nuxt/kit@4.4.6(magicast@0.5.2))(@vueuse/core@13.9.0(vue@3.5.35(typescript@6.0.3)))
+      unplugin-vue-components: 30.0.0(@babel/parser@7.29.3)(@nuxt/kit@4.4.6(magicast@0.5.2))(vue@3.5.35(typescript@6.0.3))
+      vaul-vue: 0.4.1(reka-ui@2.6.0(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(vue@3.5.35(typescript@6.0.3))
       vue-component-type-helpers: 3.2.4
     optionalDependencies:
-      valibot: 1.4.0(typescript@6.0.3)
+      valibot: 1.4.1(typescript@6.0.3)
       zod: 4.1.13
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -8910,41 +9234,41 @@ snapshots:
       - vite
       - vue
 
-  '@nuxt/ui@4.8.0(@internationalized/date@3.12.0)(@internationalized/number@3.6.5)(@tiptap/extensions@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5))(@tiptap/y-tiptap@3.0.2(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.6)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29))(db0@0.3.4)(embla-carousel@8.6.0)(ioredis@5.10.1)(magicast@0.5.2)(qrcode@1.5.4)(tailwindcss@4.3.0)(typescript@6.0.3)(valibot@1.4.0(typescript@6.0.3))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.33(typescript@6.0.3))(yjs@13.6.29)(zod@4.3.6)':
+  '@nuxt/ui@4.8.0(@internationalized/date@3.12.0)(@internationalized/number@3.6.5)(@tiptap/extensions@3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0))(@tiptap/y-tiptap@3.0.2(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.6)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29))(db0@0.3.4)(embla-carousel@8.6.0)(ioredis@5.10.1)(magicast@0.5.2)(qrcode@1.5.4)(tailwindcss@4.3.0)(typescript@6.0.3)(valibot@1.4.1(typescript@6.0.3))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.35(typescript@6.0.3))(yjs@13.6.29)(zod@4.3.6)':
     dependencies:
       '@floating-ui/dom': 1.7.6
-      '@iconify/vue': 5.0.1(vue@3.5.33(typescript@6.0.3))
+      '@iconify/vue': 5.0.1(vue@3.5.35(typescript@6.0.3))
       '@nuxt/fonts': 0.14.0(db0@0.3.4)(ioredis@5.10.1)(magicast@0.5.2)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))
-      '@nuxt/icon': 2.2.2(magicast@0.5.2)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.33(typescript@6.0.3))
+      '@nuxt/icon': 2.2.2(magicast@0.5.2)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.35(typescript@6.0.3))
       '@nuxt/kit': 4.4.6(magicast@0.5.2)
       '@nuxt/schema': 4.4.6
       '@nuxtjs/color-mode': 3.5.2(magicast@0.5.2)
       '@standard-schema/spec': 1.1.0
       '@tailwindcss/postcss': 4.3.0
       '@tailwindcss/vite': 4.3.0(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))
-      '@tanstack/vue-table': 8.21.3(vue@3.5.33(typescript@6.0.3))
-      '@tanstack/vue-virtual': 3.13.24(vue@3.5.33(typescript@6.0.3))
+      '@tanstack/vue-table': 8.21.3(vue@3.5.35(typescript@6.0.3))
+      '@tanstack/vue-virtual': 3.13.24(vue@3.5.35(typescript@6.0.3))
       '@tiptap/core': 3.22.5(@tiptap/pm@3.22.5)
       '@tiptap/extension-bubble-menu': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)
       '@tiptap/extension-code': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))
       '@tiptap/extension-collaboration': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)(@tiptap/y-tiptap@3.0.2(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.6)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29))(yjs@13.6.29)
       '@tiptap/extension-drag-handle': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/extension-collaboration@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)(@tiptap/y-tiptap@3.0.2(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.6)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29))(yjs@13.6.29))(@tiptap/extension-node-range@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)(@tiptap/y-tiptap@3.0.2(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.6)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29))
-      '@tiptap/extension-drag-handle-vue-3': 3.22.5(@tiptap/extension-drag-handle@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/extension-collaboration@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)(@tiptap/y-tiptap@3.0.2(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.6)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29))(yjs@13.6.29))(@tiptap/extension-node-range@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)(@tiptap/y-tiptap@3.0.2(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.6)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29)))(@tiptap/pm@3.22.5)(@tiptap/vue-3@3.22.5(@floating-ui/dom@1.7.6)(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)(vue@3.5.33(typescript@6.0.3)))(vue@3.5.33(typescript@6.0.3))
+      '@tiptap/extension-drag-handle-vue-3': 3.22.5(@tiptap/extension-drag-handle@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/extension-collaboration@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)(@tiptap/y-tiptap@3.0.2(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.6)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29))(yjs@13.6.29))(@tiptap/extension-node-range@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)(@tiptap/y-tiptap@3.0.2(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.6)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29)))(@tiptap/pm@3.22.5)(@tiptap/vue-3@3.22.5(@floating-ui/dom@1.7.6)(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)(vue@3.5.35(typescript@6.0.3)))(vue@3.5.35(typescript@6.0.3))
       '@tiptap/extension-floating-menu': 3.22.5(@floating-ui/dom@1.7.6)(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)
       '@tiptap/extension-horizontal-rule': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)
       '@tiptap/extension-image': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))
       '@tiptap/extension-mention': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)(@tiptap/suggestion@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5))
       '@tiptap/extension-node-range': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)
-      '@tiptap/extension-placeholder': 3.22.5(@tiptap/extensions@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5))
+      '@tiptap/extension-placeholder': 3.22.5(@tiptap/extensions@3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0))
       '@tiptap/markdown': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)
       '@tiptap/pm': 3.22.5
       '@tiptap/starter-kit': 3.22.5
       '@tiptap/suggestion': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)
-      '@tiptap/vue-3': 3.22.5(@floating-ui/dom@1.7.6)(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)(vue@3.5.33(typescript@6.0.3))
-      '@unhead/vue': 2.1.15(vue@3.5.33(typescript@6.0.3))
-      '@vueuse/core': 14.3.0(vue@3.5.33(typescript@6.0.3))
-      '@vueuse/integrations': 14.3.0(fuse.js@7.3.0)(qrcode@1.5.4)(vue@3.5.33(typescript@6.0.3))
-      '@vueuse/shared': 14.3.0(vue@3.5.33(typescript@6.0.3))
+      '@tiptap/vue-3': 3.22.5(@floating-ui/dom@1.7.6)(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)(vue@3.5.35(typescript@6.0.3))
+      '@unhead/vue': 2.1.15(vue@3.5.35(typescript@6.0.3))
+      '@vueuse/core': 14.3.0(vue@3.5.35(typescript@6.0.3))
+      '@vueuse/integrations': 14.3.0(fuse.js@7.3.0)(qrcode@1.5.4)(vue@3.5.35(typescript@6.0.3))
+      '@vueuse/shared': 14.3.0(vue@3.5.35(typescript@6.0.3))
       colortranslator: 5.0.0
       consola: 3.4.2
       defu: 6.1.7
@@ -8953,17 +9277,17 @@ snapshots:
       embla-carousel-autoplay: 8.6.0(embla-carousel@8.6.0)
       embla-carousel-class-names: 8.6.0(embla-carousel@8.6.0)
       embla-carousel-fade: 8.6.0(embla-carousel@8.6.0)
-      embla-carousel-vue: 8.6.0(vue@3.5.33(typescript@6.0.3))
+      embla-carousel-vue: 8.6.0(vue@3.5.35(typescript@6.0.3))
       embla-carousel-wheel-gestures: 8.1.0(embla-carousel@8.6.0)
       fuse.js: 7.3.0
       hookable: 6.1.1
       knitwork: 1.3.0
       magic-string: 0.30.21
       mlly: 1.8.2
-      motion-v: 2.2.1(@vueuse/core@14.3.0(vue@3.5.33(typescript@6.0.3)))(vue@3.5.33(typescript@6.0.3))
+      motion-v: 2.2.1(@vueuse/core@14.3.0(vue@3.5.35(typescript@6.0.3)))(vue@3.5.35(typescript@6.0.3))
       ohash: 2.0.11
       pathe: 2.0.3
-      reka-ui: 2.9.7(vue@3.5.33(typescript@6.0.3))
+      reka-ui: 2.9.7(vue@3.5.35(typescript@6.0.3))
       scule: 1.3.0
       tailwind-merge: 3.6.0
       tailwind-variants: 3.2.2(tailwind-merge@3.6.0)(tailwindcss@4.3.0)
@@ -8972,14 +9296,14 @@ snapshots:
       typescript: 6.0.3
       ufo: 1.6.4
       unplugin: 3.0.0
-      unplugin-auto-import: 21.0.0(@nuxt/kit@4.4.6(magicast@0.5.2))(@vueuse/core@14.3.0(vue@3.5.33(typescript@6.0.3)))
-      unplugin-vue-components: 32.0.0(@nuxt/kit@4.4.6(magicast@0.5.2))(vue@3.5.33(typescript@6.0.3))
-      vaul-vue: 0.4.1(reka-ui@2.9.7(vue@3.5.33(typescript@6.0.3)))(vue@3.5.33(typescript@6.0.3))
+      unplugin-auto-import: 21.0.0(@nuxt/kit@4.4.6(magicast@0.5.2))(@vueuse/core@14.3.0(vue@3.5.35(typescript@6.0.3)))
+      unplugin-vue-components: 32.0.0(@nuxt/kit@4.4.6(magicast@0.5.2))(vue@3.5.35(typescript@6.0.3))
+      vaul-vue: 0.4.1(reka-ui@2.9.7(vue@3.5.35(typescript@6.0.3)))(vue@3.5.35(typescript@6.0.3))
       vue-component-type-helpers: 3.3.1
     optionalDependencies:
       '@internationalized/date': 3.12.0
       '@internationalized/number': 3.6.5
-      valibot: 1.4.0(typescript@6.0.3)
+      valibot: 1.4.1(typescript@6.0.3)
       zod: 4.3.6
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -9023,7 +9347,120 @@ snapshots:
       - vue
       - yjs
 
-  '@nuxt/vite-builder@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.9.1)(lightningcss@1.32.0)(magicast@0.5.2)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(oxlint@1.43.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.33(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3))(oxlint@1.43.0)(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vue@3.5.34(typescript@6.0.3))(yaml@2.8.3)':
+  '@nuxt/ui@4.8.1(@internationalized/date@3.12.0)(@internationalized/number@3.6.5)(@tiptap/extensions@3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0))(@tiptap/y-tiptap@3.0.2(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.6)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29))(db0@0.3.4)(embla-carousel@8.6.0)(ioredis@5.10.1)(magicast@0.5.2)(qrcode@1.5.4)(tailwindcss@4.3.0)(typescript@6.0.3)(valibot@1.4.1(typescript@6.0.3))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.35(typescript@6.0.3))(yjs@13.6.29)(zod@4.3.6)':
+    dependencies:
+      '@floating-ui/dom': 1.7.6
+      '@iconify/vue': 5.0.1(vue@3.5.35(typescript@6.0.3))
+      '@nuxt/fonts': 0.14.0(db0@0.3.4)(ioredis@5.10.1)(magicast@0.5.2)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))
+      '@nuxt/icon': 2.2.2(magicast@0.5.2)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.35(typescript@6.0.3))
+      '@nuxt/kit': 4.4.6(magicast@0.5.2)
+      '@nuxt/schema': 4.4.6
+      '@nuxtjs/color-mode': 3.5.2(magicast@0.5.2)
+      '@standard-schema/spec': 1.1.0
+      '@tailwindcss/postcss': 4.3.0
+      '@tailwindcss/vite': 4.3.0(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))
+      '@tanstack/vue-table': 8.21.3(vue@3.5.35(typescript@6.0.3))
+      '@tanstack/vue-virtual': 3.13.26(vue@3.5.35(typescript@6.0.3))
+      '@tiptap/core': 3.24.0(@tiptap/pm@3.24.0)
+      '@tiptap/extension-bubble-menu': 3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0)
+      '@tiptap/extension-code': 3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))
+      '@tiptap/extension-collaboration': 3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0)(@tiptap/y-tiptap@3.0.2(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.6)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29))(yjs@13.6.29)
+      '@tiptap/extension-drag-handle': 3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/extension-collaboration@3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0)(@tiptap/y-tiptap@3.0.2(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.6)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29))(yjs@13.6.29))(@tiptap/extension-node-range@3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0)(@tiptap/y-tiptap@3.0.2(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.6)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29))
+      '@tiptap/extension-drag-handle-vue-3': 3.24.0(@tiptap/extension-drag-handle@3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/extension-collaboration@3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0)(@tiptap/y-tiptap@3.0.2(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.6)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29))(yjs@13.6.29))(@tiptap/extension-node-range@3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0)(@tiptap/y-tiptap@3.0.2(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.6)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29)))(@tiptap/pm@3.24.0)(@tiptap/vue-3@3.24.0(@floating-ui/dom@1.7.6)(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0)(vue@3.5.35(typescript@6.0.3)))(vue@3.5.35(typescript@6.0.3))
+      '@tiptap/extension-floating-menu': 3.24.0(@floating-ui/dom@1.7.6)(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0)
+      '@tiptap/extension-horizontal-rule': 3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0)
+      '@tiptap/extension-image': 3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))
+      '@tiptap/extension-mention': 3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0)(@tiptap/suggestion@3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0))
+      '@tiptap/extension-node-range': 3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0)
+      '@tiptap/extension-placeholder': 3.24.0(@tiptap/extensions@3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0))
+      '@tiptap/markdown': 3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0)
+      '@tiptap/pm': 3.24.0
+      '@tiptap/starter-kit': 3.24.0
+      '@tiptap/suggestion': 3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0)
+      '@tiptap/vue-3': 3.24.0(@floating-ui/dom@1.7.6)(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0)(vue@3.5.35(typescript@6.0.3))
+      '@unhead/vue': 2.1.15(vue@3.5.35(typescript@6.0.3))
+      '@vueuse/core': 14.3.0(vue@3.5.35(typescript@6.0.3))
+      '@vueuse/integrations': 14.3.0(fuse.js@7.3.0)(qrcode@1.5.4)(vue@3.5.35(typescript@6.0.3))
+      '@vueuse/shared': 14.3.0(vue@3.5.35(typescript@6.0.3))
+      colortranslator: 5.0.0
+      consola: 3.4.2
+      defu: 6.1.7
+      embla-carousel-auto-height: 8.6.0(embla-carousel@8.6.0)
+      embla-carousel-auto-scroll: 8.6.0(embla-carousel@8.6.0)
+      embla-carousel-autoplay: 8.6.0(embla-carousel@8.6.0)
+      embla-carousel-class-names: 8.6.0(embla-carousel@8.6.0)
+      embla-carousel-fade: 8.6.0(embla-carousel@8.6.0)
+      embla-carousel-vue: 8.6.0(vue@3.5.35(typescript@6.0.3))
+      embla-carousel-wheel-gestures: 8.1.0(embla-carousel@8.6.0)
+      fuse.js: 7.3.0
+      hookable: 6.1.1
+      knitwork: 1.3.0
+      magic-string: 0.30.21
+      mlly: 1.8.2
+      motion-v: 2.2.1(@vueuse/core@14.3.0(vue@3.5.35(typescript@6.0.3)))(vue@3.5.35(typescript@6.0.3))
+      ohash: 2.0.11
+      pathe: 2.0.3
+      reka-ui: 2.9.8(vue@3.5.35(typescript@6.0.3))
+      scule: 1.3.0
+      tailwind-merge: 3.6.0
+      tailwind-variants: 3.2.2(tailwind-merge@3.6.0)(tailwindcss@4.3.0)
+      tailwindcss: 4.3.0
+      tinyglobby: 0.2.16
+      typescript: 6.0.3
+      ufo: 1.6.4
+      unplugin: 3.0.0
+      unplugin-auto-import: 21.0.0(@nuxt/kit@4.4.6(magicast@0.5.2))(@vueuse/core@14.3.0(vue@3.5.35(typescript@6.0.3)))
+      unplugin-vue-components: 32.1.0(@nuxt/kit@4.4.6(magicast@0.5.2))(vue@3.5.35(typescript@6.0.3))
+      vaul-vue: 0.4.1(reka-ui@2.9.8(vue@3.5.35(typescript@6.0.3)))(vue@3.5.35(typescript@6.0.3))
+      vue-component-type-helpers: 3.3.1
+    optionalDependencies:
+      '@internationalized/date': 3.12.0
+      '@internationalized/number': 3.6.5
+      valibot: 1.4.1(typescript@6.0.3)
+      zod: 4.3.6
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@emotion/is-prop-valid'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@tiptap/extensions'
+      - '@tiptap/y-tiptap'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - '@vue/composition-api'
+      - async-validator
+      - aws4fetch
+      - axios
+      - change-case
+      - db0
+      - drauu
+      - embla-carousel
+      - focus-trap
+      - idb-keyval
+      - ioredis
+      - jwt-decode
+      - magicast
+      - nprogress
+      - qrcode
+      - react
+      - react-dom
+      - sortablejs
+      - universal-cookie
+      - uploadthing
+      - vite
+      - vue
+      - yjs
+
+  '@nuxt/vite-builder@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.9.1)(lightningcss@1.32.0)(magicast@0.5.2)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(oxlint@1.43.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3))(oxlint@1.43.0)(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vue@3.5.34(typescript@6.0.3))(yaml@2.8.3)':
     dependencies:
       '@nuxt/kit': 4.4.6(magicast@0.5.2)
       '@rollup/plugin-replace': 6.0.3(rollup@4.60.3)
@@ -9041,7 +9478,7 @@ snapshots:
       magic-string: 0.30.21
       mlly: 1.8.2
       mocked-exports: 0.1.1
-      nuxt: 4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(oxlint@1.43.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.33(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3)
+      nuxt: 4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(oxlint@1.43.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3)
       nypm: 0.6.6
       pathe: 2.0.3
       pkg-types: 2.3.1
@@ -9088,7 +9525,7 @@ snapshots:
       '@nuxt/kit': 3.21.2(magicast@0.5.2)
       pathe: 1.1.2
       pkg-types: 1.3.1
-      semver: 7.7.4
+      semver: 7.8.1
     transitivePeerDependencies:
       - magicast
 
@@ -9101,15 +9538,15 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxtjs/robots@6.0.7(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(oxlint@1.43.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.33(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.33(typescript@6.0.3))(zod@4.3.6)':
+  '@nuxtjs/robots@6.0.7(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(oxlint@1.43.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.35(typescript@6.0.3))(zod@4.3.6)':
     dependencies:
       '@fingerprintjs/botd': 2.0.0
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
       consola: 3.4.2
       defu: 6.1.7
       h3: 1.15.11
-      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(oxlint@1.43.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.33(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.33(typescript@6.0.3))(zod@4.3.6)
-      nuxtseo-shared: 5.1.3(c2b2690fbf1a3bc25b903503778eca4a)
+      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(oxlint@1.43.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.35(typescript@6.0.3))(zod@4.3.6)
+      nuxtseo-shared: 5.1.3(5620d8b26dd83cab43a0b8343c15798a)
       pathe: 2.0.3
       pkg-types: 2.3.0
       ufo: 1.6.3
@@ -9122,18 +9559,18 @@ snapshots:
       - vite
       - vue
 
-  '@nuxtjs/seo@5.1.3(2f74cd97bddeef2f5008a0e24db0c8ac)':
+  '@nuxtjs/seo@5.1.3(a560e8cf9cca550f7c08acddc759a1d4)':
     dependencies:
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
-      '@nuxtjs/robots': 6.0.7(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(oxlint@1.43.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.33(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.33(typescript@6.0.3))(zod@4.3.6)
-      '@nuxtjs/sitemap': 8.0.13(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(oxlint@1.43.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.33(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.33(typescript@6.0.3))(zod@4.3.6)
-      nuxt: 4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(oxlint@1.43.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.33(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3)
-      nuxt-link-checker: 5.0.9(@nuxt/schema@4.4.6)(db0@0.3.4)(ioredis@5.10.1)(magicast@0.5.2)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(oxlint@1.43.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.33(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.33(typescript@6.0.3))(zod@4.3.6)
-      nuxt-og-image: 6.4.9(@nuxt/schema@4.4.6)(@unhead/vue@2.1.15(vue@3.5.33(typescript@6.0.3)))(fontless@0.2.1(db0@0.3.4)(ioredis@5.10.1)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3)))(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(oxlint@1.43.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.33(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3))(playwright-core@1.60.0)(sharp@0.34.5)(tailwindcss@4.3.0)(unifont@0.7.4)(unstorage@1.17.5(db0@0.3.4)(ioredis@5.10.1))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.33(typescript@6.0.3))(zod@4.3.6)
-      nuxt-schema-org: 6.0.4(2b78bf46da20f4c14f409e9b1a4c9aa7)
-      nuxt-seo-utils: 8.1.9(@nuxt/schema@4.4.6)(@unhead/bundler@3.0.4(esbuild@0.28.0)(lightningcss@1.32.0)(typescript@6.0.3)(unhead@2.1.15)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3)))(esbuild@0.28.0)(lightningcss@1.32.0)(magicast@0.5.2)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(oxlint@1.43.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.33(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.33(typescript@6.0.3))(zod@4.3.6)
-      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(oxlint@1.43.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.33(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.33(typescript@6.0.3))(zod@4.3.6)
-      nuxtseo-shared: 5.1.3(c2b2690fbf1a3bc25b903503778eca4a)
+      '@nuxtjs/robots': 6.0.7(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(oxlint@1.43.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.35(typescript@6.0.3))(zod@4.3.6)
+      '@nuxtjs/sitemap': 8.0.13(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(oxlint@1.43.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.35(typescript@6.0.3))(zod@4.3.6)
+      nuxt: 4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(oxlint@1.43.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3)
+      nuxt-link-checker: 5.0.9(@nuxt/schema@4.4.6)(db0@0.3.4)(ioredis@5.10.1)(magicast@0.5.2)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(oxlint@1.43.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.35(typescript@6.0.3))(zod@4.3.6)
+      nuxt-og-image: 6.4.9(@nuxt/schema@4.4.6)(@unhead/vue@2.1.15(vue@3.5.35(typescript@6.0.3)))(fontless@0.2.1(db0@0.3.4)(ioredis@5.10.1)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3)))(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(oxlint@1.43.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3))(playwright-core@1.60.0)(sharp@0.34.5)(tailwindcss@4.3.0)(unifont@0.7.4)(unstorage@1.17.5(db0@0.3.4)(ioredis@5.10.1))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.35(typescript@6.0.3))(zod@4.3.6)
+      nuxt-schema-org: 6.0.4(436f598413ffb06fe3f1a6f9f9270f55)
+      nuxt-seo-utils: 8.1.9(@nuxt/schema@4.4.6)(@unhead/bundler@3.0.4(esbuild@0.28.0)(lightningcss@1.32.0)(typescript@6.0.3)(unhead@2.1.15)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3)))(esbuild@0.28.0)(lightningcss@1.32.0)(magicast@0.5.2)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(oxlint@1.43.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.35(typescript@6.0.3))(zod@4.3.6)
+      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(oxlint@1.43.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.35(typescript@6.0.3))(zod@4.3.6)
+      nuxtseo-shared: 5.1.3(5620d8b26dd83cab43a0b8343c15798a)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -9209,14 +9646,14 @@ snapshots:
       - yup
       - zod
 
-  '@nuxtjs/sitemap@8.0.13(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(oxlint@1.43.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.33(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.33(typescript@6.0.3))(zod@4.3.6)':
+  '@nuxtjs/sitemap@8.0.13(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(oxlint@1.43.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.35(typescript@6.0.3))(zod@4.3.6)':
     dependencies:
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
       consola: 3.4.2
       defu: 6.1.7
       fast-xml-parser: 5.7.3
-      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(oxlint@1.43.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.33(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.33(typescript@6.0.3))(zod@4.3.6)
-      nuxtseo-shared: 5.1.3(c2b2690fbf1a3bc25b903503778eca4a)
+      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(oxlint@1.43.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.35(typescript@6.0.3))(zod@4.3.6)
+      nuxtseo-shared: 5.1.3(5620d8b26dd83cab43a0b8343c15798a)
       ofetch: 1.5.1
       pathe: 2.0.3
       pkg-types: 2.3.0
@@ -9837,10 +10274,10 @@ snapshots:
       tslib: 2.8.1
       tsyringe: 4.10.0
 
-  '@pinia/nuxt@0.11.3(magicast@0.5.2)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.33(typescript@6.0.3)))':
+  '@pinia/nuxt@0.11.3(magicast@0.5.2)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))':
     dependencies:
       '@nuxt/kit': 4.3.1(magicast@0.5.2)
-      pinia: 3.0.4(typescript@6.0.3)(vue@3.5.33(typescript@6.0.3))
+      pinia: 3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3))
     transitivePeerDependencies:
       - magicast
 
@@ -10084,7 +10521,7 @@ snapshots:
     dependencies:
       '@jridgewell/remapping': 2.3.5
       enhanced-resolve: 5.19.0
-      jiti: 2.6.1
+      jiti: 2.7.0
       lightningcss: 1.30.2
       magic-string: 0.30.21
       source-map-js: 1.2.1
@@ -10236,32 +10673,51 @@ snapshots:
 
   '@tanstack/virtual-core@3.14.0': {}
 
-  '@tanstack/vue-table@8.21.3(vue@3.5.33(typescript@6.0.3))':
+  '@tanstack/virtual-core@3.16.0': {}
+
+  '@tanstack/vue-table@8.21.3(vue@3.5.35(typescript@6.0.3))':
     dependencies:
       '@tanstack/table-core': 8.21.3
-      vue: 3.5.33(typescript@6.0.3)
+      vue: 3.5.35(typescript@6.0.3)
 
-  '@tanstack/vue-virtual@3.13.18(vue@3.5.33(typescript@6.0.3))':
+  '@tanstack/vue-virtual@3.13.18(vue@3.5.35(typescript@6.0.3))':
     dependencies:
       '@tanstack/virtual-core': 3.13.18
-      vue: 3.5.33(typescript@6.0.3)
+      vue: 3.5.35(typescript@6.0.3)
 
-  '@tanstack/vue-virtual@3.13.24(vue@3.5.33(typescript@6.0.3))':
+  '@tanstack/vue-virtual@3.13.24(vue@3.5.35(typescript@6.0.3))':
     dependencies:
       '@tanstack/virtual-core': 3.14.0
-      vue: 3.5.33(typescript@6.0.3)
+      vue: 3.5.35(typescript@6.0.3)
+
+  '@tanstack/vue-virtual@3.13.26(vue@3.5.35(typescript@6.0.3))':
+    dependencies:
+      '@tanstack/virtual-core': 3.16.0
+      vue: 3.5.35(typescript@6.0.3)
 
   '@tiptap/core@3.22.5(@tiptap/pm@3.22.5)':
     dependencies:
       '@tiptap/pm': 3.22.5
 
+  '@tiptap/core@3.24.0(@tiptap/pm@3.24.0)':
+    dependencies:
+      '@tiptap/pm': 3.24.0
+
   '@tiptap/extension-blockquote@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))':
     dependencies:
       '@tiptap/core': 3.22.5(@tiptap/pm@3.22.5)
 
+  '@tiptap/extension-blockquote@3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))':
+    dependencies:
+      '@tiptap/core': 3.24.0(@tiptap/pm@3.24.0)
+
   '@tiptap/extension-bold@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))':
     dependencies:
       '@tiptap/core': 3.22.5(@tiptap/pm@3.22.5)
+
+  '@tiptap/extension-bold@3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))':
+    dependencies:
+      '@tiptap/core': 3.24.0(@tiptap/pm@3.24.0)
 
   '@tiptap/extension-bubble-menu@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)':
     dependencies:
@@ -10269,18 +10725,37 @@ snapshots:
       '@tiptap/core': 3.22.5(@tiptap/pm@3.22.5)
       '@tiptap/pm': 3.22.5
 
+  '@tiptap/extension-bubble-menu@3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0)':
+    dependencies:
+      '@floating-ui/dom': 1.7.6
+      '@tiptap/core': 3.24.0(@tiptap/pm@3.24.0)
+      '@tiptap/pm': 3.24.0
+
   '@tiptap/extension-bullet-list@3.22.5(@tiptap/extension-list@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5))':
     dependencies:
       '@tiptap/extension-list': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)
+
+  '@tiptap/extension-bullet-list@3.24.0(@tiptap/extension-list@3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0))':
+    dependencies:
+      '@tiptap/extension-list': 3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0)
 
   '@tiptap/extension-code-block@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)':
     dependencies:
       '@tiptap/core': 3.22.5(@tiptap/pm@3.22.5)
       '@tiptap/pm': 3.22.5
 
+  '@tiptap/extension-code-block@3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0)':
+    dependencies:
+      '@tiptap/core': 3.24.0(@tiptap/pm@3.24.0)
+      '@tiptap/pm': 3.24.0
+
   '@tiptap/extension-code@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))':
     dependencies:
       '@tiptap/core': 3.22.5(@tiptap/pm@3.22.5)
+
+  '@tiptap/extension-code@3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))':
+    dependencies:
+      '@tiptap/core': 3.24.0(@tiptap/pm@3.24.0)
 
   '@tiptap/extension-collaboration@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)(@tiptap/y-tiptap@3.0.2(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.6)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29))(yjs@13.6.29)':
     dependencies:
@@ -10289,16 +10764,34 @@ snapshots:
       '@tiptap/y-tiptap': 3.0.2(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.6)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29)
       yjs: 13.6.29
 
+  '@tiptap/extension-collaboration@3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0)(@tiptap/y-tiptap@3.0.2(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.6)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29))(yjs@13.6.29)':
+    dependencies:
+      '@tiptap/core': 3.24.0(@tiptap/pm@3.24.0)
+      '@tiptap/pm': 3.24.0
+      '@tiptap/y-tiptap': 3.0.2(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.6)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29)
+      yjs: 13.6.29
+
   '@tiptap/extension-document@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))':
     dependencies:
       '@tiptap/core': 3.22.5(@tiptap/pm@3.22.5)
 
-  '@tiptap/extension-drag-handle-vue-3@3.22.5(@tiptap/extension-drag-handle@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/extension-collaboration@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)(@tiptap/y-tiptap@3.0.2(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.6)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29))(yjs@13.6.29))(@tiptap/extension-node-range@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)(@tiptap/y-tiptap@3.0.2(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.6)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29)))(@tiptap/pm@3.22.5)(@tiptap/vue-3@3.22.5(@floating-ui/dom@1.7.6)(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)(vue@3.5.33(typescript@6.0.3)))(vue@3.5.33(typescript@6.0.3))':
+  '@tiptap/extension-document@3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))':
+    dependencies:
+      '@tiptap/core': 3.24.0(@tiptap/pm@3.24.0)
+
+  '@tiptap/extension-drag-handle-vue-3@3.22.5(@tiptap/extension-drag-handle@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/extension-collaboration@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)(@tiptap/y-tiptap@3.0.2(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.6)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29))(yjs@13.6.29))(@tiptap/extension-node-range@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)(@tiptap/y-tiptap@3.0.2(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.6)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29)))(@tiptap/pm@3.22.5)(@tiptap/vue-3@3.22.5(@floating-ui/dom@1.7.6)(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)(vue@3.5.35(typescript@6.0.3)))(vue@3.5.35(typescript@6.0.3))':
     dependencies:
       '@tiptap/extension-drag-handle': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/extension-collaboration@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)(@tiptap/y-tiptap@3.0.2(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.6)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29))(yjs@13.6.29))(@tiptap/extension-node-range@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)(@tiptap/y-tiptap@3.0.2(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.6)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29))
       '@tiptap/pm': 3.22.5
-      '@tiptap/vue-3': 3.22.5(@floating-ui/dom@1.7.6)(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)(vue@3.5.33(typescript@6.0.3))
-      vue: 3.5.33(typescript@6.0.3)
+      '@tiptap/vue-3': 3.22.5(@floating-ui/dom@1.7.6)(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)(vue@3.5.35(typescript@6.0.3))
+      vue: 3.5.35(typescript@6.0.3)
+
+  '@tiptap/extension-drag-handle-vue-3@3.24.0(@tiptap/extension-drag-handle@3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/extension-collaboration@3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0)(@tiptap/y-tiptap@3.0.2(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.6)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29))(yjs@13.6.29))(@tiptap/extension-node-range@3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0)(@tiptap/y-tiptap@3.0.2(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.6)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29)))(@tiptap/pm@3.24.0)(@tiptap/vue-3@3.24.0(@floating-ui/dom@1.7.6)(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0)(vue@3.5.35(typescript@6.0.3)))(vue@3.5.35(typescript@6.0.3))':
+    dependencies:
+      '@tiptap/extension-drag-handle': 3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/extension-collaboration@3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0)(@tiptap/y-tiptap@3.0.2(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.6)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29))(yjs@13.6.29))(@tiptap/extension-node-range@3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0)(@tiptap/y-tiptap@3.0.2(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.6)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29))
+      '@tiptap/pm': 3.24.0
+      '@tiptap/vue-3': 3.24.0(@floating-ui/dom@1.7.6)(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0)(vue@3.5.35(typescript@6.0.3))
+      vue: 3.5.35(typescript@6.0.3)
 
   '@tiptap/extension-drag-handle@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/extension-collaboration@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)(@tiptap/y-tiptap@3.0.2(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.6)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29))(yjs@13.6.29))(@tiptap/extension-node-range@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)(@tiptap/y-tiptap@3.0.2(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.6)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29))':
     dependencies:
@@ -10309,9 +10802,22 @@ snapshots:
       '@tiptap/pm': 3.22.5
       '@tiptap/y-tiptap': 3.0.2(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.6)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29)
 
+  '@tiptap/extension-drag-handle@3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/extension-collaboration@3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0)(@tiptap/y-tiptap@3.0.2(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.6)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29))(yjs@13.6.29))(@tiptap/extension-node-range@3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0)(@tiptap/y-tiptap@3.0.2(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.6)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29))':
+    dependencies:
+      '@floating-ui/dom': 1.7.6
+      '@tiptap/core': 3.24.0(@tiptap/pm@3.24.0)
+      '@tiptap/extension-collaboration': 3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0)(@tiptap/y-tiptap@3.0.2(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.6)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29))(yjs@13.6.29)
+      '@tiptap/extension-node-range': 3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0)
+      '@tiptap/pm': 3.24.0
+      '@tiptap/y-tiptap': 3.0.2(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.6)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29)
+
   '@tiptap/extension-dropcursor@3.22.5(@tiptap/extensions@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5))':
     dependencies:
       '@tiptap/extensions': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)
+
+  '@tiptap/extension-dropcursor@3.24.0(@tiptap/extensions@3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0))':
+    dependencies:
+      '@tiptap/extensions': 3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0)
 
   '@tiptap/extension-floating-menu@3.22.5(@floating-ui/dom@1.7.6)(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)':
     dependencies:
@@ -10319,30 +10825,61 @@ snapshots:
       '@tiptap/core': 3.22.5(@tiptap/pm@3.22.5)
       '@tiptap/pm': 3.22.5
 
+  '@tiptap/extension-floating-menu@3.24.0(@floating-ui/dom@1.7.6)(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0)':
+    dependencies:
+      '@floating-ui/dom': 1.7.6
+      '@tiptap/core': 3.24.0(@tiptap/pm@3.24.0)
+      '@tiptap/pm': 3.24.0
+
   '@tiptap/extension-gapcursor@3.22.5(@tiptap/extensions@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5))':
     dependencies:
       '@tiptap/extensions': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)
+
+  '@tiptap/extension-gapcursor@3.24.0(@tiptap/extensions@3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0))':
+    dependencies:
+      '@tiptap/extensions': 3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0)
 
   '@tiptap/extension-hard-break@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))':
     dependencies:
       '@tiptap/core': 3.22.5(@tiptap/pm@3.22.5)
 
+  '@tiptap/extension-hard-break@3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))':
+    dependencies:
+      '@tiptap/core': 3.24.0(@tiptap/pm@3.24.0)
+
   '@tiptap/extension-heading@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))':
     dependencies:
       '@tiptap/core': 3.22.5(@tiptap/pm@3.22.5)
+
+  '@tiptap/extension-heading@3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))':
+    dependencies:
+      '@tiptap/core': 3.24.0(@tiptap/pm@3.24.0)
 
   '@tiptap/extension-horizontal-rule@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)':
     dependencies:
       '@tiptap/core': 3.22.5(@tiptap/pm@3.22.5)
       '@tiptap/pm': 3.22.5
 
+  '@tiptap/extension-horizontal-rule@3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0)':
+    dependencies:
+      '@tiptap/core': 3.24.0(@tiptap/pm@3.24.0)
+      '@tiptap/pm': 3.24.0
+
   '@tiptap/extension-image@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))':
     dependencies:
       '@tiptap/core': 3.22.5(@tiptap/pm@3.22.5)
 
+  '@tiptap/extension-image@3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))':
+    dependencies:
+      '@tiptap/core': 3.24.0(@tiptap/pm@3.24.0)
+
   '@tiptap/extension-italic@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))':
     dependencies:
       '@tiptap/core': 3.22.5(@tiptap/pm@3.22.5)
+
+  '@tiptap/extension-italic@3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))':
+    dependencies:
+      '@tiptap/core': 3.24.0(@tiptap/pm@3.24.0)
 
   '@tiptap/extension-link@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)':
     dependencies:
@@ -10350,18 +10887,37 @@ snapshots:
       '@tiptap/pm': 3.22.5
       linkifyjs: 4.3.2
 
+  '@tiptap/extension-link@3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0)':
+    dependencies:
+      '@tiptap/core': 3.24.0(@tiptap/pm@3.24.0)
+      '@tiptap/pm': 3.24.0
+      linkifyjs: 4.3.3
+
   '@tiptap/extension-list-item@3.22.5(@tiptap/extension-list@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5))':
     dependencies:
       '@tiptap/extension-list': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)
+
+  '@tiptap/extension-list-item@3.24.0(@tiptap/extension-list@3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0))':
+    dependencies:
+      '@tiptap/extension-list': 3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0)
 
   '@tiptap/extension-list-keymap@3.22.5(@tiptap/extension-list@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5))':
     dependencies:
       '@tiptap/extension-list': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)
 
+  '@tiptap/extension-list-keymap@3.24.0(@tiptap/extension-list@3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0))':
+    dependencies:
+      '@tiptap/extension-list': 3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0)
+
   '@tiptap/extension-list@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)':
     dependencies:
       '@tiptap/core': 3.22.5(@tiptap/pm@3.22.5)
       '@tiptap/pm': 3.22.5
+
+  '@tiptap/extension-list@3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0)':
+    dependencies:
+      '@tiptap/core': 3.24.0(@tiptap/pm@3.24.0)
+      '@tiptap/pm': 3.24.0
 
   '@tiptap/extension-mention@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)(@tiptap/suggestion@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5))':
     dependencies:
@@ -10369,44 +10925,90 @@ snapshots:
       '@tiptap/pm': 3.22.5
       '@tiptap/suggestion': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)
 
+  '@tiptap/extension-mention@3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0)(@tiptap/suggestion@3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0))':
+    dependencies:
+      '@tiptap/core': 3.24.0(@tiptap/pm@3.24.0)
+      '@tiptap/pm': 3.24.0
+      '@tiptap/suggestion': 3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0)
+
   '@tiptap/extension-node-range@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)':
     dependencies:
       '@tiptap/core': 3.22.5(@tiptap/pm@3.22.5)
       '@tiptap/pm': 3.22.5
 
+  '@tiptap/extension-node-range@3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0)':
+    dependencies:
+      '@tiptap/core': 3.24.0(@tiptap/pm@3.24.0)
+      '@tiptap/pm': 3.24.0
+
   '@tiptap/extension-ordered-list@3.22.5(@tiptap/extension-list@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5))':
     dependencies:
       '@tiptap/extension-list': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)
+
+  '@tiptap/extension-ordered-list@3.24.0(@tiptap/extension-list@3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0))':
+    dependencies:
+      '@tiptap/extension-list': 3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0)
 
   '@tiptap/extension-paragraph@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))':
     dependencies:
       '@tiptap/core': 3.22.5(@tiptap/pm@3.22.5)
 
-  '@tiptap/extension-placeholder@3.22.5(@tiptap/extensions@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5))':
+  '@tiptap/extension-paragraph@3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))':
     dependencies:
-      '@tiptap/extensions': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)
+      '@tiptap/core': 3.24.0(@tiptap/pm@3.24.0)
+
+  '@tiptap/extension-placeholder@3.22.5(@tiptap/extensions@3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0))':
+    dependencies:
+      '@tiptap/extensions': 3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0)
+
+  '@tiptap/extension-placeholder@3.24.0(@tiptap/extensions@3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0))':
+    dependencies:
+      '@tiptap/extensions': 3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0)
 
   '@tiptap/extension-strike@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))':
     dependencies:
       '@tiptap/core': 3.22.5(@tiptap/pm@3.22.5)
 
+  '@tiptap/extension-strike@3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))':
+    dependencies:
+      '@tiptap/core': 3.24.0(@tiptap/pm@3.24.0)
+
   '@tiptap/extension-text@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))':
     dependencies:
       '@tiptap/core': 3.22.5(@tiptap/pm@3.22.5)
 
+  '@tiptap/extension-text@3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))':
+    dependencies:
+      '@tiptap/core': 3.24.0(@tiptap/pm@3.24.0)
+
   '@tiptap/extension-underline@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))':
     dependencies:
       '@tiptap/core': 3.22.5(@tiptap/pm@3.22.5)
+
+  '@tiptap/extension-underline@3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))':
+    dependencies:
+      '@tiptap/core': 3.24.0(@tiptap/pm@3.24.0)
 
   '@tiptap/extensions@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)':
     dependencies:
       '@tiptap/core': 3.22.5(@tiptap/pm@3.22.5)
       '@tiptap/pm': 3.22.5
 
+  '@tiptap/extensions@3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0)':
+    dependencies:
+      '@tiptap/core': 3.24.0(@tiptap/pm@3.24.0)
+      '@tiptap/pm': 3.24.0
+
   '@tiptap/markdown@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)':
     dependencies:
       '@tiptap/core': 3.22.5(@tiptap/pm@3.22.5)
       '@tiptap/pm': 3.22.5
+      marked: 17.0.4
+
+  '@tiptap/markdown@3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0)':
+    dependencies:
+      '@tiptap/core': 3.24.0(@tiptap/pm@3.24.0)
+      '@tiptap/pm': 3.24.0
       marked: 17.0.4
 
   '@tiptap/pm@3.22.5':
@@ -10416,6 +11018,22 @@ snapshots:
       prosemirror-dropcursor: 1.8.2
       prosemirror-gapcursor: 1.4.0
       prosemirror-history: 1.5.0
+      prosemirror-keymap: 1.2.3
+      prosemirror-model: 1.25.4
+      prosemirror-schema-list: 1.5.1
+      prosemirror-state: 1.4.4
+      prosemirror-tables: 1.8.5
+      prosemirror-transform: 1.11.0
+      prosemirror-view: 1.41.6
+
+  '@tiptap/pm@3.24.0':
+    dependencies:
+      prosemirror-changeset: 2.3.1
+      prosemirror-commands: 1.7.1
+      prosemirror-dropcursor: 1.8.2
+      prosemirror-gapcursor: 1.4.0
+      prosemirror-history: 1.5.0
+      prosemirror-inputrules: 1.5.1
       prosemirror-keymap: 1.2.3
       prosemirror-model: 1.25.4
       prosemirror-schema-list: 1.5.1
@@ -10451,20 +11069,62 @@ snapshots:
       '@tiptap/extensions': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)
       '@tiptap/pm': 3.22.5
 
+  '@tiptap/starter-kit@3.24.0':
+    dependencies:
+      '@tiptap/core': 3.24.0(@tiptap/pm@3.24.0)
+      '@tiptap/extension-blockquote': 3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))
+      '@tiptap/extension-bold': 3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))
+      '@tiptap/extension-bullet-list': 3.24.0(@tiptap/extension-list@3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0))
+      '@tiptap/extension-code': 3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))
+      '@tiptap/extension-code-block': 3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0)
+      '@tiptap/extension-document': 3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))
+      '@tiptap/extension-dropcursor': 3.24.0(@tiptap/extensions@3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0))
+      '@tiptap/extension-gapcursor': 3.24.0(@tiptap/extensions@3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0))
+      '@tiptap/extension-hard-break': 3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))
+      '@tiptap/extension-heading': 3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))
+      '@tiptap/extension-horizontal-rule': 3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0)
+      '@tiptap/extension-italic': 3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))
+      '@tiptap/extension-link': 3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0)
+      '@tiptap/extension-list': 3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0)
+      '@tiptap/extension-list-item': 3.24.0(@tiptap/extension-list@3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0))
+      '@tiptap/extension-list-keymap': 3.24.0(@tiptap/extension-list@3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0))
+      '@tiptap/extension-ordered-list': 3.24.0(@tiptap/extension-list@3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0))
+      '@tiptap/extension-paragraph': 3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))
+      '@tiptap/extension-strike': 3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))
+      '@tiptap/extension-text': 3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))
+      '@tiptap/extension-underline': 3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))
+      '@tiptap/extensions': 3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0)
+      '@tiptap/pm': 3.24.0
+
   '@tiptap/suggestion@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)':
     dependencies:
       '@tiptap/core': 3.22.5(@tiptap/pm@3.22.5)
       '@tiptap/pm': 3.22.5
 
-  '@tiptap/vue-3@3.22.5(@floating-ui/dom@1.7.6)(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)(vue@3.5.33(typescript@6.0.3))':
+  '@tiptap/suggestion@3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0)':
+    dependencies:
+      '@tiptap/core': 3.24.0(@tiptap/pm@3.24.0)
+      '@tiptap/pm': 3.24.0
+
+  '@tiptap/vue-3@3.22.5(@floating-ui/dom@1.7.6)(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)(vue@3.5.35(typescript@6.0.3))':
     dependencies:
       '@floating-ui/dom': 1.7.6
       '@tiptap/core': 3.22.5(@tiptap/pm@3.22.5)
       '@tiptap/pm': 3.22.5
-      vue: 3.5.33(typescript@6.0.3)
+      vue: 3.5.35(typescript@6.0.3)
     optionalDependencies:
       '@tiptap/extension-bubble-menu': 3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)
       '@tiptap/extension-floating-menu': 3.22.5(@floating-ui/dom@1.7.6)(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)
+
+  '@tiptap/vue-3@3.24.0(@floating-ui/dom@1.7.6)(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0)(vue@3.5.35(typescript@6.0.3))':
+    dependencies:
+      '@floating-ui/dom': 1.7.6
+      '@tiptap/core': 3.24.0(@tiptap/pm@3.24.0)
+      '@tiptap/pm': 3.24.0
+      vue: 3.5.35(typescript@6.0.3)
+    optionalDependencies:
+      '@tiptap/extension-bubble-menu': 3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0)
+      '@tiptap/extension-floating-menu': 3.24.0(@floating-ui/dom@1.7.6)(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0)
 
   '@tiptap/y-tiptap@3.0.2(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.6)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29)':
     dependencies:
@@ -10553,30 +11213,30 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@unhead/schema-org@2.1.12(@unhead/vue@2.1.15(vue@3.5.33(typescript@6.0.3)))':
+  '@unhead/schema-org@2.1.12(@unhead/vue@2.1.15(vue@3.5.35(typescript@6.0.3)))':
     dependencies:
       ufo: 1.6.3
       unhead: 2.1.13
     optionalDependencies:
-      '@unhead/vue': 2.1.15(vue@3.5.33(typescript@6.0.3))
+      '@unhead/vue': 2.1.15(vue@3.5.35(typescript@6.0.3))
 
-  '@unhead/vue@2.1.13(vue@3.5.33(typescript@6.0.3))':
+  '@unhead/vue@2.1.13(vue@3.5.35(typescript@6.0.3))':
     dependencies:
       hookable: 6.1.1
       unhead: 2.1.13
-      vue: 3.5.33(typescript@6.0.3)
-
-  '@unhead/vue@2.1.15(vue@3.5.33(typescript@6.0.3))':
-    dependencies:
-      hookable: 6.1.1
-      unhead: 2.1.15
-      vue: 3.5.33(typescript@6.0.3)
+      vue: 3.5.35(typescript@6.0.3)
 
   '@unhead/vue@2.1.15(vue@3.5.34(typescript@6.0.3))':
     dependencies:
       hookable: 6.1.1
       unhead: 2.1.15
       vue: 3.5.34(typescript@6.0.3)
+
+  '@unhead/vue@2.1.15(vue@3.5.35(typescript@6.0.3))':
+    dependencies:
+      hookable: 6.1.1
+      unhead: 2.1.15
+      vue: 3.5.35(typescript@6.0.3)
 
   '@vercel/nft@1.5.0(rollup@4.60.3)':
     dependencies:
@@ -10615,7 +11275,7 @@ snapshots:
       ohash: 2.0.11
       p-limit: 7.3.0
       structured-clone-es: 2.0.0
-      valibot: 1.4.0(typescript@6.0.3)
+      valibot: 1.4.1(typescript@6.0.3)
       ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
@@ -10634,11 +11294,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue@6.0.7(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.33(typescript@6.0.3))':
+  '@vitejs/plugin-vue@6.0.7(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.35(typescript@6.0.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
       vite: 7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3)
-      vue: 3.5.33(typescript@6.0.3)
+      vue: 3.5.35(typescript@6.0.3)
 
   '@vitejs/plugin-vue@6.0.7(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.34(typescript@6.0.3))':
     dependencies:
@@ -10742,6 +11402,14 @@ snapshots:
       estree-walker: 2.0.2
       source-map-js: 1.2.1
 
+  '@vue/compiler-core@3.5.35':
+    dependencies:
+      '@babel/parser': 7.29.3
+      '@vue/shared': 3.5.35
+      entities: 7.0.1
+      estree-walker: 2.0.2
+      source-map-js: 1.2.1
+
   '@vue/compiler-dom@3.5.33':
     dependencies:
       '@vue/compiler-core': 3.5.33
@@ -10751,6 +11419,11 @@ snapshots:
     dependencies:
       '@vue/compiler-core': 3.5.34
       '@vue/shared': 3.5.34
+
+  '@vue/compiler-dom@3.5.35':
+    dependencies:
+      '@vue/compiler-core': 3.5.35
+      '@vue/shared': 3.5.35
 
   '@vue/compiler-sfc@3.5.33':
     dependencies:
@@ -10776,6 +11449,18 @@ snapshots:
       postcss: 8.5.14
       source-map-js: 1.2.1
 
+  '@vue/compiler-sfc@3.5.35':
+    dependencies:
+      '@babel/parser': 7.29.3
+      '@vue/compiler-core': 3.5.35
+      '@vue/compiler-dom': 3.5.35
+      '@vue/compiler-ssr': 3.5.35
+      '@vue/shared': 3.5.35
+      estree-walker: 2.0.2
+      magic-string: 0.30.21
+      postcss: 8.5.15
+      source-map-js: 1.2.1
+
   '@vue/compiler-ssr@3.5.33':
     dependencies:
       '@vue/compiler-dom': 3.5.33
@@ -10786,6 +11471,11 @@ snapshots:
       '@vue/compiler-dom': 3.5.34
       '@vue/shared': 3.5.34
 
+  '@vue/compiler-ssr@3.5.35':
+    dependencies:
+      '@vue/compiler-dom': 3.5.35
+      '@vue/shared': 3.5.35
+
   '@vue/devtools-api@7.7.9':
     dependencies:
       '@vue/devtools-kit': 7.7.9
@@ -10794,17 +11484,17 @@ snapshots:
     dependencies:
       '@vue/devtools-kit': 8.1.2
 
-  '@vue/devtools-core@8.1.1(vue@3.5.33(typescript@6.0.3))':
-    dependencies:
-      '@vue/devtools-kit': 8.1.1
-      '@vue/devtools-shared': 8.1.1
-      vue: 3.5.33(typescript@6.0.3)
-
   '@vue/devtools-core@8.1.1(vue@3.5.34(typescript@6.0.3))':
     dependencies:
       '@vue/devtools-kit': 8.1.1
       '@vue/devtools-shared': 8.1.1
       vue: 3.5.34(typescript@6.0.3)
+
+  '@vue/devtools-core@8.1.1(vue@3.5.35(typescript@6.0.3))':
+    dependencies:
+      '@vue/devtools-kit': 8.1.1
+      '@vue/devtools-shared': 8.1.1
+      vue: 3.5.35(typescript@6.0.3)
 
   '@vue/devtools-kit@7.7.9':
     dependencies:
@@ -10855,6 +11545,10 @@ snapshots:
     dependencies:
       '@vue/shared': 3.5.34
 
+  '@vue/reactivity@3.5.35':
+    dependencies:
+      '@vue/shared': 3.5.35
+
   '@vue/runtime-core@3.5.33':
     dependencies:
       '@vue/reactivity': 3.5.33
@@ -10864,6 +11558,11 @@ snapshots:
     dependencies:
       '@vue/reactivity': 3.5.34
       '@vue/shared': 3.5.34
+
+  '@vue/runtime-core@3.5.35':
+    dependencies:
+      '@vue/reactivity': 3.5.35
+      '@vue/shared': 3.5.35
 
   '@vue/runtime-dom@3.5.33':
     dependencies:
@@ -10879,18 +11578,18 @@ snapshots:
       '@vue/shared': 3.5.34
       csstype: 3.2.3
 
+  '@vue/runtime-dom@3.5.35':
+    dependencies:
+      '@vue/reactivity': 3.5.35
+      '@vue/runtime-core': 3.5.35
+      '@vue/shared': 3.5.35
+      csstype: 3.2.3
+
   '@vue/server-renderer@3.5.33(vue@3.5.33(typescript@6.0.3))':
     dependencies:
       '@vue/compiler-ssr': 3.5.33
       '@vue/shared': 3.5.33
       vue: 3.5.33(typescript@6.0.3)
-
-  '@vue/server-renderer@3.5.34(vue@3.5.33(typescript@6.0.3))':
-    dependencies:
-      '@vue/compiler-ssr': 3.5.34
-      '@vue/shared': 3.5.34
-      vue: 3.5.33(typescript@6.0.3)
-    optional: true
 
   '@vue/server-renderer@3.5.34(vue@3.5.34(typescript@6.0.3))':
     dependencies:
@@ -10898,25 +11597,33 @@ snapshots:
       '@vue/shared': 3.5.34
       vue: 3.5.34(typescript@6.0.3)
 
+  '@vue/server-renderer@3.5.35(vue@3.5.35(typescript@6.0.3))':
+    dependencies:
+      '@vue/compiler-ssr': 3.5.35
+      '@vue/shared': 3.5.35
+      vue: 3.5.35(typescript@6.0.3)
+
   '@vue/shared@3.5.33': {}
 
   '@vue/shared@3.5.34': {}
 
-  '@vue/test-utils@2.4.10(@vue/compiler-dom@3.5.34)(@vue/server-renderer@3.5.34(vue@3.5.33(typescript@6.0.3)))(vue@3.5.33(typescript@6.0.3))':
+  '@vue/shared@3.5.35': {}
+
+  '@vue/test-utils@2.4.10(@vue/compiler-dom@3.5.35)(@vue/server-renderer@3.5.35(vue@3.5.35(typescript@6.0.3)))(vue@3.5.35(typescript@6.0.3))':
     dependencies:
-      '@vue/compiler-dom': 3.5.34
+      '@vue/compiler-dom': 3.5.35
       js-beautify: 1.15.4
-      vue: 3.5.33(typescript@6.0.3)
+      vue: 3.5.35(typescript@6.0.3)
       vue-component-type-helpers: 3.2.7
     optionalDependencies:
-      '@vue/server-renderer': 3.5.34(vue@3.5.33(typescript@6.0.3))
+      '@vue/server-renderer': 3.5.35(vue@3.5.35(typescript@6.0.3))
 
-  '@vueuse/core@10.11.1(vue@3.5.33(typescript@6.0.3))':
+  '@vueuse/core@10.11.1(vue@3.5.35(typescript@6.0.3))':
     dependencies:
       '@types/web-bluetooth': 0.0.20
       '@vueuse/metadata': 10.11.1
-      '@vueuse/shared': 10.11.1(vue@3.5.33(typescript@6.0.3))
-      vue-demi: 0.14.10(vue@3.5.33(typescript@6.0.3))
+      '@vueuse/shared': 10.11.1(vue@3.5.35(typescript@6.0.3))
+      vue-demi: 0.14.10(vue@3.5.35(typescript@6.0.3))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
@@ -10930,41 +11637,41 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@vueuse/core@13.9.0(vue@3.5.33(typescript@6.0.3))':
+  '@vueuse/core@13.9.0(vue@3.5.35(typescript@6.0.3))':
     dependencies:
       '@types/web-bluetooth': 0.0.21
       '@vueuse/metadata': 13.9.0
-      '@vueuse/shared': 13.9.0(vue@3.5.33(typescript@6.0.3))
-      vue: 3.5.33(typescript@6.0.3)
+      '@vueuse/shared': 13.9.0(vue@3.5.35(typescript@6.0.3))
+      vue: 3.5.35(typescript@6.0.3)
 
-  '@vueuse/core@14.2.1(vue@3.5.33(typescript@6.0.3))':
+  '@vueuse/core@14.2.1(vue@3.5.35(typescript@6.0.3))':
     dependencies:
       '@types/web-bluetooth': 0.0.21
       '@vueuse/metadata': 14.2.1
-      '@vueuse/shared': 14.2.1(vue@3.5.33(typescript@6.0.3))
-      vue: 3.5.33(typescript@6.0.3)
+      '@vueuse/shared': 14.2.1(vue@3.5.35(typescript@6.0.3))
+      vue: 3.5.35(typescript@6.0.3)
 
-  '@vueuse/core@14.3.0(vue@3.5.33(typescript@6.0.3))':
+  '@vueuse/core@14.3.0(vue@3.5.35(typescript@6.0.3))':
     dependencies:
       '@types/web-bluetooth': 0.0.21
       '@vueuse/metadata': 14.3.0
-      '@vueuse/shared': 14.3.0(vue@3.5.33(typescript@6.0.3))
-      vue: 3.5.33(typescript@6.0.3)
+      '@vueuse/shared': 14.3.0(vue@3.5.35(typescript@6.0.3))
+      vue: 3.5.35(typescript@6.0.3)
 
-  '@vueuse/integrations@13.9.0(fuse.js@7.1.0)(qrcode@1.5.4)(vue@3.5.33(typescript@6.0.3))':
+  '@vueuse/integrations@13.9.0(fuse.js@7.1.0)(qrcode@1.5.4)(vue@3.5.35(typescript@6.0.3))':
     dependencies:
-      '@vueuse/core': 13.9.0(vue@3.5.33(typescript@6.0.3))
-      '@vueuse/shared': 13.9.0(vue@3.5.33(typescript@6.0.3))
-      vue: 3.5.33(typescript@6.0.3)
+      '@vueuse/core': 13.9.0(vue@3.5.35(typescript@6.0.3))
+      '@vueuse/shared': 13.9.0(vue@3.5.35(typescript@6.0.3))
+      vue: 3.5.35(typescript@6.0.3)
     optionalDependencies:
       fuse.js: 7.1.0
       qrcode: 1.5.4
 
-  '@vueuse/integrations@14.3.0(fuse.js@7.3.0)(qrcode@1.5.4)(vue@3.5.33(typescript@6.0.3))':
+  '@vueuse/integrations@14.3.0(fuse.js@7.3.0)(qrcode@1.5.4)(vue@3.5.35(typescript@6.0.3))':
     dependencies:
-      '@vueuse/core': 14.3.0(vue@3.5.33(typescript@6.0.3))
-      '@vueuse/shared': 14.3.0(vue@3.5.33(typescript@6.0.3))
-      vue: 3.5.33(typescript@6.0.3)
+      '@vueuse/core': 14.3.0(vue@3.5.35(typescript@6.0.3))
+      '@vueuse/shared': 14.3.0(vue@3.5.35(typescript@6.0.3))
+      vue: 3.5.35(typescript@6.0.3)
     optionalDependencies:
       fuse.js: 7.3.0
       qrcode: 1.5.4
@@ -10979,20 +11686,20 @@ snapshots:
 
   '@vueuse/metadata@14.3.0': {}
 
-  '@vueuse/nuxt@14.3.0(magicast@0.5.2)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(oxlint@1.43.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.33(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3))(vue@3.5.33(typescript@6.0.3))':
+  '@vueuse/nuxt@14.3.0(magicast@0.5.2)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(oxlint@1.43.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3))(vue@3.5.35(typescript@6.0.3))':
     dependencies:
       '@nuxt/kit': 4.4.4(magicast@0.5.2)
-      '@vueuse/core': 14.3.0(vue@3.5.33(typescript@6.0.3))
+      '@vueuse/core': 14.3.0(vue@3.5.35(typescript@6.0.3))
       '@vueuse/metadata': 14.3.0
       local-pkg: 1.1.2
-      nuxt: 4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(oxlint@1.43.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.33(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3)
-      vue: 3.5.33(typescript@6.0.3)
+      nuxt: 4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(oxlint@1.43.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3)
+      vue: 3.5.35(typescript@6.0.3)
     transitivePeerDependencies:
       - magicast
 
-  '@vueuse/shared@10.11.1(vue@3.5.33(typescript@6.0.3))':
+  '@vueuse/shared@10.11.1(vue@3.5.35(typescript@6.0.3))':
     dependencies:
-      vue-demi: 0.14.10(vue@3.5.33(typescript@6.0.3))
+      vue-demi: 0.14.10(vue@3.5.35(typescript@6.0.3))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
@@ -11003,17 +11710,17 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@vueuse/shared@13.9.0(vue@3.5.33(typescript@6.0.3))':
+  '@vueuse/shared@13.9.0(vue@3.5.35(typescript@6.0.3))':
     dependencies:
-      vue: 3.5.33(typescript@6.0.3)
+      vue: 3.5.35(typescript@6.0.3)
 
-  '@vueuse/shared@14.2.1(vue@3.5.33(typescript@6.0.3))':
+  '@vueuse/shared@14.2.1(vue@3.5.35(typescript@6.0.3))':
     dependencies:
-      vue: 3.5.33(typescript@6.0.3)
+      vue: 3.5.35(typescript@6.0.3)
 
-  '@vueuse/shared@14.3.0(vue@3.5.33(typescript@6.0.3))':
+  '@vueuse/shared@14.3.0(vue@3.5.35(typescript@6.0.3))':
     dependencies:
-      vue: 3.5.33(typescript@6.0.3)
+      vue: 3.5.35(typescript@6.0.3)
 
   abbrev@2.0.0: {}
 
@@ -11100,7 +11807,7 @@ snapshots:
 
   ast-walker-scope@0.8.3:
     dependencies:
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.3
       ast-kit: 2.2.0
 
   async-sema@3.1.1: {}
@@ -11128,16 +11835,16 @@ snapshots:
 
   baseline-browser-mapping@2.10.29: {}
 
-  better-auth@1.6.11(mongodb@7.2.0)(vitest@4.1.7(@types/node@25.9.1)(happy-dom@20.9.0)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3)))(vue@3.5.33(typescript@6.0.3)):
+  better-auth@1.6.13(mongodb@7.2.0)(vitest@4.1.7(@types/node@25.9.1)(happy-dom@20.9.0)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3)))(vue@3.5.35(typescript@6.0.3)):
     dependencies:
-      '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.1.1)
-      '@better-auth/drizzle-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.1.1))(@better-auth/utils@0.4.0)
-      '@better-auth/kysely-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.1.1))(@better-auth/utils@0.4.0)(kysely@0.28.17)
-      '@better-auth/memory-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.1.1))(@better-auth/utils@0.4.0)
-      '@better-auth/mongo-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.1.1))(@better-auth/utils@0.4.0)(mongodb@7.2.0)
-      '@better-auth/prisma-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.1.1))(@better-auth/utils@0.4.0)
-      '@better-auth/telemetry': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.1.1))(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)
-      '@better-auth/utils': 0.4.0
+      '@better-auth/core': 1.6.13(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.1.1)
+      '@better-auth/drizzle-adapter': 1.6.13(@better-auth/core@1.6.13(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.1.1))(@better-auth/utils@0.4.1)
+      '@better-auth/kysely-adapter': 1.6.13(@better-auth/core@1.6.13(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.1.1))(@better-auth/utils@0.4.1)(kysely@0.28.17)
+      '@better-auth/memory-adapter': 1.6.13(@better-auth/core@1.6.13(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.1.1))(@better-auth/utils@0.4.1)
+      '@better-auth/mongo-adapter': 1.6.13(@better-auth/core@1.6.13(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.1.1))(@better-auth/utils@0.4.1)(mongodb@7.2.0)
+      '@better-auth/prisma-adapter': 1.6.13(@better-auth/core@1.6.13(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.1.1))(@better-auth/utils@0.4.1)
+      '@better-auth/telemetry': 1.6.13(@better-auth/core@1.6.13(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.17)(nanostores@1.1.1))(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)
+      '@better-auth/utils': 0.4.1
       '@better-fetch/fetch': 1.1.21
       '@noble/ciphers': 2.1.1
       '@noble/hashes': 2.0.1
@@ -11150,7 +11857,7 @@ snapshots:
     optionalDependencies:
       mongodb: 7.2.0
       vitest: 4.1.7(@types/node@25.9.1)(happy-dom@20.9.0)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))
-      vue: 3.5.33(typescript@6.0.3)
+      vue: 3.5.35(typescript@6.0.3)
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
@@ -11596,11 +12303,11 @@ snapshots:
     dependencies:
       embla-carousel: 8.6.0
 
-  embla-carousel-vue@8.6.0(vue@3.5.33(typescript@6.0.3)):
+  embla-carousel-vue@8.6.0(vue@3.5.35(typescript@6.0.3)):
     dependencies:
       embla-carousel: 8.6.0
       embla-carousel-reactive-utils: 8.6.0(embla-carousel@8.6.0)
-      vue: 3.5.33(typescript@6.0.3)
+      vue: 3.5.35(typescript@6.0.3)
 
   embla-carousel-wheel-gestures@8.1.0(embla-carousel@8.6.0):
     dependencies:
@@ -11880,7 +12587,7 @@ snapshots:
       defu: 6.1.7
       esbuild: 0.25.12
       fontaine: 0.7.0
-      jiti: 2.6.1
+      jiti: 2.7.0
       lightningcss: 1.32.0
       magic-string: 0.30.21
       ohash: 2.0.11
@@ -11918,7 +12625,7 @@ snapshots:
       defu: 6.1.7
       esbuild: 0.27.3
       fontaine: 0.8.0
-      jiti: 2.6.1
+      jiti: 2.7.0
       lightningcss: 1.32.0
       magic-string: 0.30.21
       ohash: 2.0.11
@@ -11958,8 +12665,8 @@ snapshots:
 
   framer-motion@12.34.0:
     dependencies:
-      motion-dom: 12.34.0
-      motion-utils: 12.29.2
+      motion-dom: 12.38.0
+      motion-utils: 12.36.0
       tslib: 2.8.1
 
   framer-motion@12.38.0:
@@ -12443,14 +13150,16 @@ snapshots:
 
   linkifyjs@4.3.2: {}
 
-  lint-staged@17.0.5:
+  linkifyjs@4.3.3: {}
+
+  lint-staged@17.0.7:
     dependencies:
       listr2: 10.2.1
       picomatch: 4.0.4
       string-argv: 0.3.2
-      tinyexec: 1.1.2
+      tinyexec: 1.2.4
     optionalDependencies:
-      yaml: 2.8.4
+      yaml: 2.9.0
 
   listhen@1.10.0:
     dependencies:
@@ -12507,6 +13216,12 @@ snapshots:
     dependencies:
       mlly: 1.8.0
       pkg-types: 2.3.0
+      quansync: 0.2.11
+
+  local-pkg@1.2.1:
+    dependencies:
+      mlly: 1.8.2
+      pkg-types: 2.3.1
       quansync: 0.2.11
 
   locate-path@5.0.0:
@@ -12577,10 +13292,10 @@ snapshots:
     dependencies:
       estree-walker: 3.0.3
       magic-string: 0.30.21
-      mlly: 1.8.0
+      mlly: 1.8.2
       regexp-tree: 0.1.27
       type-level-regexp: 0.1.17
-      ufo: 1.6.3
+      ufo: 1.6.4
       unplugin: 2.3.11
 
   magic-regexp@0.11.0:
@@ -12699,7 +13414,7 @@ snapshots:
       acorn: 8.16.0
       pathe: 2.0.3
       pkg-types: 1.3.1
-      ufo: 1.6.3
+      ufo: 1.6.4
 
   mocked-exports@0.1.1: {}
 
@@ -12718,36 +13433,34 @@ snapshots:
 
   motion-dom@12.34.0:
     dependencies:
-      motion-utils: 12.29.2
+      motion-utils: 12.36.0
 
   motion-dom@12.38.0:
     dependencies:
       motion-utils: 12.36.0
 
-  motion-utils@12.29.2: {}
-
   motion-utils@12.36.0: {}
 
-  motion-v@1.10.2(@vueuse/core@13.9.0(vue@3.5.33(typescript@6.0.3)))(vue@3.5.33(typescript@6.0.3)):
+  motion-v@1.10.2(@vueuse/core@13.9.0(vue@3.5.35(typescript@6.0.3)))(vue@3.5.35(typescript@6.0.3)):
     dependencies:
-      '@vueuse/core': 13.9.0(vue@3.5.33(typescript@6.0.3))
+      '@vueuse/core': 13.9.0(vue@3.5.35(typescript@6.0.3))
       framer-motion: 12.34.0
       hey-listen: 1.0.8
       motion-dom: 12.34.0
-      vue: 3.5.33(typescript@6.0.3)
+      vue: 3.5.35(typescript@6.0.3)
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
       - react
       - react-dom
 
-  motion-v@2.2.1(@vueuse/core@14.3.0(vue@3.5.33(typescript@6.0.3)))(vue@3.5.33(typescript@6.0.3)):
+  motion-v@2.2.1(@vueuse/core@14.3.0(vue@3.5.35(typescript@6.0.3)))(vue@3.5.35(typescript@6.0.3)):
     dependencies:
-      '@vueuse/core': 14.3.0(vue@3.5.33(typescript@6.0.3))
+      '@vueuse/core': 14.3.0(vue@3.5.35(typescript@6.0.3))
       framer-motion: 12.38.0
       hey-listen: 1.0.8
       motion-dom: 12.38.0
       motion-utils: 12.36.0
-      vue: 3.5.33(typescript@6.0.3)
+      vue: 3.5.35(typescript@6.0.3)
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
       - react
@@ -12760,6 +13473,8 @@ snapshots:
   muggle-string@0.4.1: {}
 
   nanoid@3.3.11: {}
+
+  nanoid@3.3.12: {}
 
   nanostores@1.1.1: {}
 
@@ -12907,17 +13622,17 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  nuxt-link-checker@5.0.9(@nuxt/schema@4.4.6)(db0@0.3.4)(ioredis@5.10.1)(magicast@0.5.2)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(oxlint@1.43.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.33(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.33(typescript@6.0.3))(zod@4.3.6):
+  nuxt-link-checker@5.0.9(@nuxt/schema@4.4.6)(db0@0.3.4)(ioredis@5.10.1)(magicast@0.5.2)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(oxlint@1.43.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.35(typescript@6.0.3))(zod@4.3.6):
     dependencies:
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
-      '@vueuse/core': 14.2.1(vue@3.5.33(typescript@6.0.3))
+      '@vueuse/core': 14.2.1(vue@3.5.35(typescript@6.0.3))
       consola: 3.4.2
       diff: 8.0.4
       fuse.js: 7.3.0
       magic-string: 0.30.21
-      nuxt: 4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(oxlint@1.43.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.33(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3)
-      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(oxlint@1.43.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.33(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.33(typescript@6.0.3))(zod@4.3.6)
-      nuxtseo-shared: 5.1.3(c2b2690fbf1a3bc25b903503778eca4a)
+      nuxt: 4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(oxlint@1.43.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3)
+      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(oxlint@1.43.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.35(typescript@6.0.3))(zod@4.3.6)
+      nuxtseo-shared: 5.1.3(5620d8b26dd83cab43a0b8343c15798a)
       ofetch: 1.5.1
       pathe: 2.0.3
       pkg-types: 2.3.0
@@ -12951,12 +13666,12 @@ snapshots:
       - vue
       - zod
 
-  nuxt-og-image@6.4.9(@nuxt/schema@4.4.6)(@unhead/vue@2.1.15(vue@3.5.33(typescript@6.0.3)))(fontless@0.2.1(db0@0.3.4)(ioredis@5.10.1)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3)))(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(oxlint@1.43.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.33(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3))(playwright-core@1.60.0)(sharp@0.34.5)(tailwindcss@4.3.0)(unifont@0.7.4)(unstorage@1.17.5(db0@0.3.4)(ioredis@5.10.1))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.33(typescript@6.0.3))(zod@4.3.6):
+  nuxt-og-image@6.4.9(@nuxt/schema@4.4.6)(@unhead/vue@2.1.15(vue@3.5.35(typescript@6.0.3)))(fontless@0.2.1(db0@0.3.4)(ioredis@5.10.1)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3)))(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(oxlint@1.43.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3))(playwright-core@1.60.0)(sharp@0.34.5)(tailwindcss@4.3.0)(unifont@0.7.4)(unstorage@1.17.5(db0@0.3.4)(ioredis@5.10.1))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.35(typescript@6.0.3))(zod@4.3.6):
     dependencies:
       '@clack/prompts': 1.3.0
       '@nuxt/kit': 4.4.4(magicast@0.5.2)
-      '@unhead/vue': 2.1.15(vue@3.5.33(typescript@6.0.3))
-      '@vue/compiler-sfc': 3.5.33
+      '@unhead/vue': 2.1.15(vue@3.5.35(typescript@6.0.3))
+      '@vue/compiler-sfc': 3.5.34
       chrome-launcher: 1.2.1
       consola: 3.4.2
       culori: 4.0.2
@@ -12967,8 +13682,8 @@ snapshots:
       magic-string: 0.30.21
       magicast: 0.5.2
       mocked-exports: 0.1.1
-      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(oxlint@1.43.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.33(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.33(typescript@6.0.3))(zod@4.3.6)
-      nuxtseo-shared: 5.1.3(c2b2690fbf1a3bc25b903503778eca4a)
+      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(oxlint@1.43.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.35(typescript@6.0.3))(zod@4.3.6)
+      nuxtseo-shared: 5.1.3(5620d8b26dd83cab43a0b8343c15798a)
       nypm: 0.6.6
       ofetch: 1.5.1
       ohash: 2.0.11
@@ -12999,17 +13714,17 @@ snapshots:
       - vue
       - zod
 
-  nuxt-schema-org@6.0.4(2b78bf46da20f4c14f409e9b1a4c9aa7):
+  nuxt-schema-org@6.0.4(436f598413ffb06fe3f1a6f9f9270f55):
     dependencies:
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
-      '@unhead/schema-org': 2.1.12(@unhead/vue@2.1.15(vue@3.5.33(typescript@6.0.3)))
+      '@unhead/schema-org': 2.1.12(@unhead/vue@2.1.15(vue@3.5.35(typescript@6.0.3)))
       defu: 6.1.7
-      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(oxlint@1.43.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.33(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.33(typescript@6.0.3))(zod@4.3.6)
-      nuxtseo-layer-devtools: 0.5.1(752a971fc79bd47c4018b537a6e175ac)
-      nuxtseo-shared: 0.9.0(c2b2690fbf1a3bc25b903503778eca4a)
+      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(oxlint@1.43.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.35(typescript@6.0.3))(zod@4.3.6)
+      nuxtseo-layer-devtools: 0.5.1(85d9fe18e35963bad895041aa748be21)
+      nuxtseo-shared: 0.9.0(5620d8b26dd83cab43a0b8343c15798a)
       pkg-types: 2.3.0
     optionalDependencies:
-      '@unhead/vue': 2.1.15(vue@3.5.33(typescript@6.0.3))
+      '@unhead/vue': 2.1.15(vue@3.5.35(typescript@6.0.3))
       unhead: 2.1.15
       zod: 4.3.6
     transitivePeerDependencies:
@@ -13070,7 +13785,7 @@ snapshots:
       - yjs
       - yup
 
-  nuxt-seo-utils@8.1.9(@nuxt/schema@4.4.6)(@unhead/bundler@3.0.4(esbuild@0.28.0)(lightningcss@1.32.0)(typescript@6.0.3)(unhead@2.1.15)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3)))(esbuild@0.28.0)(lightningcss@1.32.0)(magicast@0.5.2)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(oxlint@1.43.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.33(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.33(typescript@6.0.3))(zod@4.3.6):
+  nuxt-seo-utils@8.1.9(@nuxt/schema@4.4.6)(@unhead/bundler@3.0.4(esbuild@0.28.0)(lightningcss@1.32.0)(typescript@6.0.3)(unhead@2.1.15)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3)))(esbuild@0.28.0)(lightningcss@1.32.0)(magicast@0.5.2)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(oxlint@1.43.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.35(typescript@6.0.3))(zod@4.3.6):
     dependencies:
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
       '@unhead/addons': 3.0.4(@unhead/bundler@3.0.4(esbuild@0.28.0)(lightningcss@1.32.0)(typescript@6.0.3)(unhead@2.1.15)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3)))
@@ -13078,9 +13793,9 @@ snapshots:
       defu: 6.1.7
       escape-string-regexp: 5.0.0
       image-size: 2.0.2
-      nuxt: 4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(oxlint@1.43.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.33(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3)
-      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(oxlint@1.43.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.33(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.33(typescript@6.0.3))(zod@4.3.6)
-      nuxtseo-shared: 5.1.3(c2b2690fbf1a3bc25b903503778eca4a)
+      nuxt: 4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(oxlint@1.43.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3)
+      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(oxlint@1.43.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.35(typescript@6.0.3))(zod@4.3.6)
+      nuxtseo-shared: 5.1.3(5620d8b26dd83cab43a0b8343c15798a)
       pathe: 2.0.3
       pkg-types: 2.3.0
       scule: 1.3.0
@@ -13098,25 +13813,25 @@ snapshots:
       - vue
       - zod
 
-  nuxt-site-config-kit@4.0.8(magicast@0.5.2)(vue@3.5.33(typescript@6.0.3)):
+  nuxt-site-config-kit@4.0.8(magicast@0.5.2)(vue@3.5.35(typescript@6.0.3)):
     dependencies:
-      '@nuxt/kit': 4.4.2(magicast@0.5.2)
-      site-config-stack: 4.0.8(vue@3.5.33(typescript@6.0.3))
+      '@nuxt/kit': 4.4.6(magicast@0.5.2)
+      site-config-stack: 4.0.8(vue@3.5.35(typescript@6.0.3))
       std-env: 4.0.0
       ufo: 1.6.3
     transitivePeerDependencies:
       - magicast
       - vue
 
-  nuxt-site-config@4.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(oxlint@1.43.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.33(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.33(typescript@6.0.3))(zod@4.3.6):
+  nuxt-site-config@4.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(oxlint@1.43.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.35(typescript@6.0.3))(zod@4.3.6):
     dependencies:
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
       h3: 1.15.11
-      nuxt-site-config-kit: 4.0.8(magicast@0.5.2)(vue@3.5.33(typescript@6.0.3))
-      nuxtseo-shared: 5.1.3(c2b2690fbf1a3bc25b903503778eca4a)
+      nuxt-site-config-kit: 4.0.8(magicast@0.5.2)(vue@3.5.35(typescript@6.0.3))
+      nuxtseo-shared: 5.1.3(5620d8b26dd83cab43a0b8343c15798a)
       pathe: 2.0.3
       pkg-types: 2.3.0
-      site-config-stack: 4.0.8(vue@3.5.33(typescript@6.0.3))
+      site-config-stack: 4.0.8(vue@3.5.35(typescript@6.0.3))
       ufo: 1.6.3
     transitivePeerDependencies:
       - '@nuxt/schema'
@@ -13126,16 +13841,16 @@ snapshots:
       - vue
       - zod
 
-  nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(oxlint@1.43.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.33(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3):
+  nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(oxlint@1.43.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3):
     dependencies:
       '@dxup/nuxt': 0.4.1(magicast@0.5.2)(typescript@6.0.3)
       '@nuxt/cli': 3.35.2(@nuxt/schema@4.4.6)(cac@6.7.14)(magicast@0.5.2)
       '@nuxt/devtools': 3.2.4(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.34(typescript@6.0.3))
       '@nuxt/kit': 4.4.6(magicast@0.5.2)
-      '@nuxt/nitro-server': 4.4.6(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(db0@0.3.4)(ioredis@5.10.1)(magicast@0.5.2)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(oxlint@1.43.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.33(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3))(oxc-parser@0.131.0)(typescript@6.0.3)
+      '@nuxt/nitro-server': 4.4.6(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(db0@0.3.4)(ioredis@5.10.1)(magicast@0.5.2)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(oxlint@1.43.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3))(oxc-parser@0.131.0)(typescript@6.0.3)
       '@nuxt/schema': 4.4.6
       '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.4.6(magicast@0.5.2))
-      '@nuxt/vite-builder': 4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.9.1)(lightningcss@1.32.0)(magicast@0.5.2)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(oxlint@1.43.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.33(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3))(oxlint@1.43.0)(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vue@3.5.34(typescript@6.0.3))(yaml@2.8.3)
+      '@nuxt/vite-builder': 4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.9.1)(lightningcss@1.32.0)(magicast@0.5.2)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(oxlint@1.43.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3))(oxlint@1.43.0)(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vue@3.5.34(typescript@6.0.3))(yaml@2.8.3)
       '@unhead/vue': 2.1.15(vue@3.5.34(typescript@6.0.3))
       '@vue/shared': 3.5.34
       chokidar: 5.0.0
@@ -13182,7 +13897,7 @@ snapshots:
       unrouting: 0.1.7
       untyped: 2.0.0
       vue: 3.5.34(typescript@6.0.3)
-      vue-router: 5.0.7(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.33(typescript@6.0.3)))(vue@3.5.34(typescript@6.0.3))
+      vue-router: 5.0.7(@vue/compiler-sfc@3.5.35)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(vue@3.5.34(typescript@6.0.3))
     optionalDependencies:
       '@parcel/watcher': 2.5.6
       '@types/node': 25.9.1
@@ -13254,15 +13969,15 @@ snapshots:
       - xml2js
       - yaml
 
-  nuxtseo-layer-devtools@0.5.1(752a971fc79bd47c4018b537a6e175ac):
+  nuxtseo-layer-devtools@0.5.1(85d9fe18e35963bad895041aa748be21):
     dependencies:
       '@nuxt/devtools-kit': 4.0.0-alpha.3(magicast@0.5.2)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))
-      '@nuxt/kit': 4.4.2(magicast@0.5.2)
-      '@nuxt/ui': 4.8.0(@internationalized/date@3.12.0)(@internationalized/number@3.6.5)(@tiptap/extensions@3.22.5(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5))(@tiptap/y-tiptap@3.0.2(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.6)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29))(db0@0.3.4)(embla-carousel@8.6.0)(ioredis@5.10.1)(magicast@0.5.2)(qrcode@1.5.4)(tailwindcss@4.3.0)(typescript@6.0.3)(valibot@1.4.0(typescript@6.0.3))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.33(typescript@6.0.3))(yjs@13.6.29)(zod@4.3.6)
+      '@nuxt/kit': 4.4.6(magicast@0.5.2)
+      '@nuxt/ui': 4.8.0(@internationalized/date@3.12.0)(@internationalized/number@3.6.5)(@tiptap/extensions@3.24.0(@tiptap/core@3.24.0(@tiptap/pm@3.24.0))(@tiptap/pm@3.24.0))(@tiptap/y-tiptap@3.0.2(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.6)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29))(db0@0.3.4)(embla-carousel@8.6.0)(ioredis@5.10.1)(magicast@0.5.2)(qrcode@1.5.4)(tailwindcss@4.3.0)(typescript@6.0.3)(valibot@1.4.1(typescript@6.0.3))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.35(typescript@6.0.3))(yjs@13.6.29)(zod@4.3.6)
       '@shikijs/langs': 4.0.2
       '@shikijs/themes': 4.0.2
-      '@vueuse/nuxt': 14.3.0(magicast@0.5.2)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(oxlint@1.43.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.33(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3))(vue@3.5.33(typescript@6.0.3))
-      nuxtseo-shared: 0.9.0(c2b2690fbf1a3bc25b903503778eca4a)
+      '@vueuse/nuxt': 14.3.0(magicast@0.5.2)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(oxlint@1.43.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3))(vue@3.5.35(typescript@6.0.3))
+      nuxtseo-shared: 0.9.0(5620d8b26dd83cab43a0b8343c15798a)
       ofetch: 1.5.1
       shiki: 4.0.2
       ufo: 1.6.3
@@ -13323,16 +14038,16 @@ snapshots:
       - yup
       - zod
 
-  nuxtseo-shared@0.9.0(c2b2690fbf1a3bc25b903503778eca4a):
+  nuxtseo-shared@0.9.0(5620d8b26dd83cab43a0b8343c15798a):
     dependencies:
       '@clack/prompts': 1.2.0
       '@nuxt/devtools-kit': 4.0.0-alpha.3(magicast@0.5.2)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))
-      '@nuxt/kit': 4.4.2(magicast@0.5.2)
+      '@nuxt/kit': 4.4.6(magicast@0.5.2)
       '@nuxt/schema': 4.4.6
       birpc: 4.0.0
       consola: 3.4.2
       defu: 6.1.7
-      nuxt: 4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(oxlint@1.43.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.33(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3)
+      nuxt: 4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(oxlint@1.43.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3)
       ofetch: 1.5.1
       pathe: 2.0.3
       pkg-types: 2.3.0
@@ -13340,15 +14055,15 @@ snapshots:
       sirv: 3.0.2
       std-env: 4.0.0
       ufo: 1.6.3
-      vue: 3.5.33(typescript@6.0.3)
+      vue: 3.5.35(typescript@6.0.3)
     optionalDependencies:
-      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(oxlint@1.43.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.33(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.33(typescript@6.0.3))(zod@4.3.6)
+      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(oxlint@1.43.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.35(typescript@6.0.3))(zod@4.3.6)
       zod: 4.3.6
     transitivePeerDependencies:
       - magicast
       - vite
 
-  nuxtseo-shared@5.1.3(c2b2690fbf1a3bc25b903503778eca4a):
+  nuxtseo-shared@5.1.3(5620d8b26dd83cab43a0b8343c15798a):
     dependencies:
       '@clack/prompts': 1.2.0
       '@nuxt/devtools-kit': 4.0.0-alpha.3(magicast@0.5.2)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))
@@ -13357,7 +14072,7 @@ snapshots:
       birpc: 4.0.0
       consola: 3.4.2
       defu: 6.1.7
-      nuxt: 4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(oxlint@1.43.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.33(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3)
+      nuxt: 4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(oxlint@1.43.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3)
       ofetch: 1.5.1
       pathe: 2.0.3
       pkg-types: 2.3.0
@@ -13365,9 +14080,9 @@ snapshots:
       sirv: 3.0.2
       std-env: 4.0.0
       ufo: 1.6.3
-      vue: 3.5.33(typescript@6.0.3)
+      vue: 3.5.35(typescript@6.0.3)
     optionalDependencies:
-      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(oxlint@1.43.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.33(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.33(typescript@6.0.3))(zod@4.3.6)
+      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(oxlint@1.43.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3))(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.35(typescript@6.0.3))(zod@4.3.6)
       zod: 4.3.6
     transitivePeerDependencies:
       - magicast
@@ -13383,7 +14098,7 @@ snapshots:
     dependencies:
       citty: 0.2.2
       pathe: 2.0.3
-      tinyexec: 1.1.1
+      tinyexec: 1.1.2
 
   obug@2.1.1: {}
 
@@ -13679,17 +14394,17 @@ snapshots:
 
   picomatch@4.0.4: {}
 
-  pinia@3.0.4(typescript@6.0.3)(vue@3.5.33(typescript@6.0.3)):
+  pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)):
     dependencies:
       '@vue/devtools-api': 7.7.9
-      vue: 3.5.33(typescript@6.0.3)
+      vue: 3.5.35(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
 
   pkg-types@1.3.1:
     dependencies:
       confbox: 0.1.8
-      mlly: 1.8.0
+      mlly: 1.8.2
       pathe: 2.0.3
 
   pkg-types@2.3.0:
@@ -13883,6 +14598,12 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  postcss@8.5.15:
+    dependencies:
+      nanoid: 3.3.12
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
   powershell-utils@0.1.0: {}
 
   pretty-bytes@7.1.0: {}
@@ -13928,6 +14649,11 @@ snapshots:
       prosemirror-transform: 1.11.0
       prosemirror-view: 1.41.6
       rope-sequence: 1.3.4
+
+  prosemirror-inputrules@1.5.1:
+    dependencies:
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.11.0
 
   prosemirror-keymap@1.2.3:
     dependencies:
@@ -14055,36 +14781,52 @@ snapshots:
 
   regexp-tree@0.1.27: {}
 
-  reka-ui@2.6.0(typescript@6.0.3)(vue@3.5.33(typescript@6.0.3)):
+  reka-ui@2.6.0(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)):
     dependencies:
       '@floating-ui/dom': 1.7.6
-      '@floating-ui/vue': 1.1.10(vue@3.5.33(typescript@6.0.3))
+      '@floating-ui/vue': 1.1.10(vue@3.5.35(typescript@6.0.3))
       '@internationalized/date': 3.11.0
       '@internationalized/number': 3.6.5
-      '@tanstack/vue-virtual': 3.13.24(vue@3.5.33(typescript@6.0.3))
+      '@tanstack/vue-virtual': 3.13.24(vue@3.5.35(typescript@6.0.3))
       '@vueuse/core': 12.8.2(typescript@6.0.3)
       '@vueuse/shared': 12.8.2(typescript@6.0.3)
       aria-hidden: 1.2.6
       defu: 6.1.7
       ohash: 2.0.11
-      vue: 3.5.33(typescript@6.0.3)
+      vue: 3.5.35(typescript@6.0.3)
     transitivePeerDependencies:
       - '@vue/composition-api'
       - typescript
 
-  reka-ui@2.9.7(vue@3.5.33(typescript@6.0.3)):
+  reka-ui@2.9.7(vue@3.5.35(typescript@6.0.3)):
     dependencies:
       '@floating-ui/dom': 1.7.6
-      '@floating-ui/vue': 1.1.10(vue@3.5.33(typescript@6.0.3))
+      '@floating-ui/vue': 1.1.10(vue@3.5.35(typescript@6.0.3))
       '@internationalized/date': 3.12.0
       '@internationalized/number': 3.6.5
-      '@tanstack/vue-virtual': 3.13.24(vue@3.5.33(typescript@6.0.3))
-      '@vueuse/core': 14.3.0(vue@3.5.33(typescript@6.0.3))
-      '@vueuse/shared': 14.3.0(vue@3.5.33(typescript@6.0.3))
+      '@tanstack/vue-virtual': 3.13.24(vue@3.5.35(typescript@6.0.3))
+      '@vueuse/core': 14.3.0(vue@3.5.35(typescript@6.0.3))
+      '@vueuse/shared': 14.3.0(vue@3.5.35(typescript@6.0.3))
       aria-hidden: 1.2.6
       defu: 6.1.7
       ohash: 2.0.11
-      vue: 3.5.33(typescript@6.0.3)
+      vue: 3.5.35(typescript@6.0.3)
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+
+  reka-ui@2.9.8(vue@3.5.35(typescript@6.0.3)):
+    dependencies:
+      '@floating-ui/dom': 1.7.6
+      '@floating-ui/vue': 1.1.10(vue@3.5.35(typescript@6.0.3))
+      '@internationalized/date': 3.12.0
+      '@internationalized/number': 3.6.5
+      '@tanstack/vue-virtual': 3.13.24(vue@3.5.35(typescript@6.0.3))
+      '@vueuse/core': 14.3.0(vue@3.5.35(typescript@6.0.3))
+      '@vueuse/shared': 14.3.0(vue@3.5.35(typescript@6.0.3))
+      aria-hidden: 1.2.6
+      defu: 6.1.7
+      ohash: 2.0.11
+      vue: 3.5.35(typescript@6.0.3)
     transitivePeerDependencies:
       - '@vue/composition-api'
 
@@ -14284,10 +15026,10 @@ snapshots:
 
   sisteransi@1.0.5: {}
 
-  site-config-stack@4.0.8(vue@3.5.33(typescript@6.0.3)):
+  site-config-stack@4.0.8(vue@3.5.35(typescript@6.0.3)):
     dependencies:
       ufo: 1.6.3
-      vue: 3.5.33(typescript@6.0.3)
+      vue: 3.5.35(typescript@6.0.3)
 
   slash@5.1.0: {}
 
@@ -14498,6 +15240,8 @@ snapshots:
 
   tinyexec@1.1.2: {}
 
+  tinyexec@1.2.4: {}
+
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
@@ -14577,7 +15321,7 @@ snapshots:
 
   unhead@2.1.13:
     dependencies:
-      hookable: 6.1.0
+      hookable: 6.1.1
 
   unhead@2.1.15:
     dependencies:
@@ -14668,19 +15412,7 @@ snapshots:
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
 
-  unplugin-auto-import@20.3.0(@nuxt/kit@4.4.4(magicast@0.5.2))(@vueuse/core@13.9.0(vue@3.5.33(typescript@6.0.3))):
-    dependencies:
-      local-pkg: 1.1.2
-      magic-string: 0.30.21
-      picomatch: 4.0.4
-      unimport: 5.6.0
-      unplugin: 2.3.11
-      unplugin-utils: 0.3.1
-    optionalDependencies:
-      '@nuxt/kit': 4.4.4(magicast@0.5.2)
-      '@vueuse/core': 13.9.0(vue@3.5.33(typescript@6.0.3))
-
-  unplugin-auto-import@21.0.0(@nuxt/kit@4.4.6(magicast@0.5.2))(@vueuse/core@14.3.0(vue@3.5.33(typescript@6.0.3))):
+  unplugin-auto-import@20.3.0(@nuxt/kit@4.4.6(magicast@0.5.2))(@vueuse/core@13.9.0(vue@3.5.35(typescript@6.0.3))):
     dependencies:
       local-pkg: 1.1.2
       magic-string: 0.30.21
@@ -14690,14 +15422,26 @@ snapshots:
       unplugin-utils: 0.3.1
     optionalDependencies:
       '@nuxt/kit': 4.4.6(magicast@0.5.2)
-      '@vueuse/core': 14.3.0(vue@3.5.33(typescript@6.0.3))
+      '@vueuse/core': 13.9.0(vue@3.5.35(typescript@6.0.3))
+
+  unplugin-auto-import@21.0.0(@nuxt/kit@4.4.6(magicast@0.5.2))(@vueuse/core@14.3.0(vue@3.5.35(typescript@6.0.3))):
+    dependencies:
+      local-pkg: 1.1.2
+      magic-string: 0.30.21
+      picomatch: 4.0.4
+      unimport: 5.6.0
+      unplugin: 2.3.11
+      unplugin-utils: 0.3.1
+    optionalDependencies:
+      '@nuxt/kit': 4.4.6(magicast@0.5.2)
+      '@vueuse/core': 14.3.0(vue@3.5.35(typescript@6.0.3))
 
   unplugin-utils@0.3.1:
     dependencies:
       pathe: 2.0.3
       picomatch: 4.0.4
 
-  unplugin-vue-components@30.0.0(@babel/parser@7.29.3)(@nuxt/kit@4.4.4(magicast@0.5.2))(vue@3.5.33(typescript@6.0.3)):
+  unplugin-vue-components@30.0.0(@babel/parser@7.29.3)(@nuxt/kit@4.4.6(magicast@0.5.2))(vue@3.5.35(typescript@6.0.3)):
     dependencies:
       chokidar: 4.0.3
       debug: 4.4.3
@@ -14707,14 +15451,14 @@ snapshots:
       tinyglobby: 0.2.16
       unplugin: 2.3.11
       unplugin-utils: 0.3.1
-      vue: 3.5.33(typescript@6.0.3)
+      vue: 3.5.35(typescript@6.0.3)
     optionalDependencies:
       '@babel/parser': 7.29.3
-      '@nuxt/kit': 4.4.4(magicast@0.5.2)
+      '@nuxt/kit': 4.4.6(magicast@0.5.2)
     transitivePeerDependencies:
       - supports-color
 
-  unplugin-vue-components@32.0.0(@nuxt/kit@4.4.6(magicast@0.5.2))(vue@3.5.33(typescript@6.0.3)):
+  unplugin-vue-components@32.0.0(@nuxt/kit@4.4.6(magicast@0.5.2))(vue@3.5.35(typescript@6.0.3)):
     dependencies:
       chokidar: 5.0.0
       local-pkg: 1.1.2
@@ -14725,7 +15469,22 @@ snapshots:
       tinyglobby: 0.2.16
       unplugin: 3.0.0
       unplugin-utils: 0.3.1
-      vue: 3.5.33(typescript@6.0.3)
+      vue: 3.5.35(typescript@6.0.3)
+    optionalDependencies:
+      '@nuxt/kit': 4.4.6(magicast@0.5.2)
+
+  unplugin-vue-components@32.1.0(@nuxt/kit@4.4.6(magicast@0.5.2))(vue@3.5.35(typescript@6.0.3)):
+    dependencies:
+      chokidar: 5.0.0
+      local-pkg: 1.2.1
+      magic-string: 0.30.21
+      mlly: 1.8.2
+      obug: 2.1.1
+      picomatch: 4.0.4
+      tinyglobby: 0.2.16
+      unplugin: 3.0.0
+      unplugin-utils: 0.3.1
+      vue: 3.5.35(typescript@6.0.3)
     optionalDependencies:
       '@nuxt/kit': 4.4.6(magicast@0.5.2)
 
@@ -14816,23 +15575,31 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  valibot@1.4.0(typescript@6.0.3):
+  valibot@1.4.1(typescript@6.0.3):
     optionalDependencies:
       typescript: 6.0.3
 
-  vaul-vue@0.4.1(reka-ui@2.6.0(typescript@6.0.3)(vue@3.5.33(typescript@6.0.3)))(vue@3.5.33(typescript@6.0.3)):
+  vaul-vue@0.4.1(reka-ui@2.6.0(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(vue@3.5.35(typescript@6.0.3)):
     dependencies:
-      '@vueuse/core': 10.11.1(vue@3.5.33(typescript@6.0.3))
-      reka-ui: 2.6.0(typescript@6.0.3)(vue@3.5.33(typescript@6.0.3))
-      vue: 3.5.33(typescript@6.0.3)
+      '@vueuse/core': 10.11.1(vue@3.5.35(typescript@6.0.3))
+      reka-ui: 2.6.0(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3))
+      vue: 3.5.35(typescript@6.0.3)
     transitivePeerDependencies:
       - '@vue/composition-api'
 
-  vaul-vue@0.4.1(reka-ui@2.9.7(vue@3.5.33(typescript@6.0.3)))(vue@3.5.33(typescript@6.0.3)):
+  vaul-vue@0.4.1(reka-ui@2.9.7(vue@3.5.35(typescript@6.0.3)))(vue@3.5.35(typescript@6.0.3)):
     dependencies:
-      '@vueuse/core': 10.11.1(vue@3.5.33(typescript@6.0.3))
-      reka-ui: 2.9.7(vue@3.5.33(typescript@6.0.3))
-      vue: 3.5.33(typescript@6.0.3)
+      '@vueuse/core': 10.11.1(vue@3.5.35(typescript@6.0.3))
+      reka-ui: 2.9.7(vue@3.5.35(typescript@6.0.3))
+      vue: 3.5.35(typescript@6.0.3)
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+
+  vaul-vue@0.4.1(reka-ui@2.9.8(vue@3.5.35(typescript@6.0.3)))(vue@3.5.35(typescript@6.0.3)):
+    dependencies:
+      '@vueuse/core': 10.11.1(vue@3.5.35(typescript@6.0.3))
+      reka-ui: 2.9.8(vue@3.5.35(typescript@6.0.3))
+      vue: 3.5.35(typescript@6.0.3)
     transitivePeerDependencies:
       - '@vue/composition-api'
 
@@ -14909,16 +15676,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-vue-tracer@1.3.0(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.33(typescript@6.0.3)):
-    dependencies:
-      estree-walker: 3.0.3
-      exsolve: 1.0.8
-      magic-string: 0.30.21
-      pathe: 2.0.3
-      source-map-js: 1.2.1
-      vite: 7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3)
-      vue: 3.5.33(typescript@6.0.3)
-
   vite-plugin-vue-tracer@1.3.0(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.34(typescript@6.0.3)):
     dependencies:
       estree-walker: 3.0.3
@@ -14928,6 +15685,16 @@ snapshots:
       source-map-js: 1.2.1
       vite: 7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3)
       vue: 3.5.34(typescript@6.0.3)
+
+  vite-plugin-vue-tracer@1.3.0(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vue@3.5.35(typescript@6.0.3)):
+    dependencies:
+      estree-walker: 3.0.3
+      exsolve: 1.0.8
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      source-map-js: 1.2.1
+      vite: 7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3)
+      vue: 3.5.35(typescript@6.0.3)
 
   vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3):
     dependencies:
@@ -14961,9 +15728,9 @@ snapshots:
       terser: 5.46.0
       yaml: 2.8.3
 
-  vitest-environment-nuxt@2.0.0(@playwright/test@1.60.0)(@vue/test-utils@2.4.10(@vue/compiler-dom@3.5.34)(@vue/server-renderer@3.5.34(vue@3.5.33(typescript@6.0.3)))(vue@3.5.33(typescript@6.0.3)))(happy-dom@20.9.0)(magicast@0.5.2)(playwright-core@1.60.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vitest@4.1.7(@types/node@25.9.1)(happy-dom@20.9.0)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))):
+  vitest-environment-nuxt@2.0.0(@playwright/test@1.60.0)(@vue/test-utils@2.4.10(@vue/compiler-dom@3.5.35)(@vue/server-renderer@3.5.35(vue@3.5.35(typescript@6.0.3)))(vue@3.5.35(typescript@6.0.3)))(happy-dom@20.9.0)(magicast@0.5.2)(playwright-core@1.60.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vitest@4.1.7(@types/node@25.9.1)(happy-dom@20.9.0)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))):
     dependencies:
-      '@nuxt/test-utils': 4.0.3(@playwright/test@1.60.0)(@vue/test-utils@2.4.10(@vue/compiler-dom@3.5.34)(@vue/server-renderer@3.5.34(vue@3.5.33(typescript@6.0.3)))(vue@3.5.33(typescript@6.0.3)))(happy-dom@20.9.0)(magicast@0.5.2)(playwright-core@1.60.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vitest@4.1.7(@types/node@25.9.1)(happy-dom@20.9.0)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3)))
+      '@nuxt/test-utils': 4.0.3(@playwright/test@1.60.0)(@vue/test-utils@2.4.10(@vue/compiler-dom@3.5.35)(@vue/server-renderer@3.5.35(vue@3.5.35(typescript@6.0.3)))(vue@3.5.35(typescript@6.0.3)))(happy-dom@20.9.0)(magicast@0.5.2)(playwright-core@1.60.0)(typescript@6.0.3)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3))(vitest@4.1.7(@types/node@25.9.1)(happy-dom@20.9.0)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.3)))
     transitivePeerDependencies:
       - '@cucumber/cucumber'
       - '@jest/globals'
@@ -15020,13 +15787,13 @@ snapshots:
 
   vue-component-type-helpers@3.3.1: {}
 
-  vue-demi@0.14.10(vue@3.5.33(typescript@6.0.3)):
+  vue-demi@0.14.10(vue@3.5.35(typescript@6.0.3)):
     dependencies:
-      vue: 3.5.33(typescript@6.0.3)
+      vue: 3.5.35(typescript@6.0.3)
 
   vue-devtools-stub@0.1.0: {}
 
-  vue-router@5.0.7(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.33(typescript@6.0.3)))(vue@3.5.34(typescript@6.0.3)):
+  vue-router@5.0.7(@vue/compiler-sfc@3.5.35)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(vue@3.5.34(typescript@6.0.3)):
     dependencies:
       '@babel/generator': 8.0.0-rc.5
       '@vue-macros/common': 3.1.2(vue@3.5.34(typescript@6.0.3))
@@ -15047,8 +15814,8 @@ snapshots:
       vue: 3.5.34(typescript@6.0.3)
       yaml: 2.8.3
     optionalDependencies:
-      '@vue/compiler-sfc': 3.5.34
-      pinia: 3.0.4(typescript@6.0.3)(vue@3.5.33(typescript@6.0.3))
+      '@vue/compiler-sfc': 3.5.35
+      pinia: 3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3))
 
   vue@3.5.33(typescript@6.0.3):
     dependencies:
@@ -15067,6 +15834,16 @@ snapshots:
       '@vue/runtime-dom': 3.5.34
       '@vue/server-renderer': 3.5.34(vue@3.5.34(typescript@6.0.3))
       '@vue/shared': 3.5.34
+    optionalDependencies:
+      typescript: 6.0.3
+
+  vue@3.5.35(typescript@6.0.3):
+    dependencies:
+      '@vue/compiler-dom': 3.5.35
+      '@vue/compiler-sfc': 3.5.35
+      '@vue/runtime-dom': 3.5.35
+      '@vue/server-renderer': 3.5.35(vue@3.5.35(typescript@6.0.3))
+      '@vue/shared': 3.5.35
     optionalDependencies:
       typescript: 6.0.3
 
@@ -15171,7 +15948,7 @@ snapshots:
 
   yaml@2.8.3: {}
 
-  yaml@2.8.4:
+  yaml@2.9.0:
     optional: true
 
   yargs-parser@18.1.3:

--- a/nuxt-base-template/pnpm-lock.yaml
+++ b/nuxt-base-template/pnpm-lock.yaml
@@ -115,9 +115,6 @@ importers:
       '@vue/test-utils':
         specifier: 2.4.10
         version: 2.4.10(@vue/compiler-dom@3.5.34)(@vue/server-renderer@3.5.34(vue@3.5.33(typescript@6.0.3)))(vue@3.5.33(typescript@6.0.3))
-      dayjs-nuxt:
-        specifier: 2.1.11
-        version: 2.1.11(magicast@0.5.2)
       happy-dom:
         specifier: 20.9.0
         version: 20.9.0
@@ -1218,10 +1215,6 @@ packages:
   '@nuxt/image@2.0.0':
     resolution: {integrity: sha512-otHi6gAoYXKLrp8m27ZjX1PjxOPaltQ4OiUs/BhkW995mF/vXf8SWQTw68fww+Uric0v+XgoVrP9icDi+yT6zw==}
     engines: {node: '>=18.20.6'}
-
-  '@nuxt/kit@3.21.1':
-    resolution: {integrity: sha512-QORZRjcuTKgo++XP1Pc2c2gqwRydkaExrIRfRI9vFsPA3AzuHVn5Gfmbv1ic8y34e78mr5DMBvJlelUaeOuajg==}
-    engines: {node: '>=18.12.0'}
 
   '@nuxt/kit@3.21.2':
     resolution: {integrity: sha512-Bd6m6mrDrqpBEbX+g0rc66/ALd1sxlgdx5nfK9MAYO0yKLTOSK7McSYz1KcOYn3LQFCXOWfvXwaqih/b+REI1g==}
@@ -4115,12 +4108,6 @@ packages:
 
   custom-error-instance@2.1.1:
     resolution: {integrity: sha512-p6JFxJc3M4OTD2li2qaHkDCw9SfMw82Ldr6OC9Je1aXiGfhx2W8p3GaoeaGrPJTUN9NirTM/KTxHWMUdR1rsUg==}
-
-  dayjs-nuxt@2.1.11:
-    resolution: {integrity: sha512-KDDNiET7KAKf6yzL3RaPWq5aV7ql9QTt5fIDYv+4eOegDmnEQGjwkKYADDystsKtPjt7QZerpVbhC96o3BIyqQ==}
-
-  dayjs@1.11.19:
-    resolution: {integrity: sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==}
 
   db0@0.3.4:
     resolution: {integrity: sha512-RiXXi4WaNzPTHEOu8UPQKMooIbqOEyqA1t7Z6MsdxSCeb8iUC9ko3LcmsLmeUt2SM5bctfArZKkRQggKZz7JNw==}
@@ -8544,32 +8531,6 @@ snapshots:
       - magicast
       - uploadthing
 
-  '@nuxt/kit@3.21.1(magicast@0.5.2)':
-    dependencies:
-      c12: 3.3.3(magicast@0.5.2)
-      consola: 3.4.2
-      defu: 6.1.7
-      destr: 2.0.5
-      errx: 0.1.0
-      exsolve: 1.0.8
-      ignore: 7.0.5
-      jiti: 2.6.1
-      klona: 2.0.6
-      knitwork: 1.3.0
-      mlly: 1.8.0
-      ohash: 2.0.11
-      pathe: 2.0.3
-      pkg-types: 2.3.0
-      rc9: 3.0.0
-      scule: 1.3.0
-      semver: 7.7.4
-      tinyglobby: 0.2.15
-      ufo: 1.6.3
-      unctx: 2.5.0
-      untyped: 2.0.0
-    transitivePeerDependencies:
-      - magicast
-
   '@nuxt/kit@3.21.2(magicast@0.5.2)':
     dependencies:
       c12: 3.3.4(magicast@0.5.2)
@@ -11524,15 +11485,6 @@ snapshots:
   culori@4.0.2: {}
 
   custom-error-instance@2.1.1: {}
-
-  dayjs-nuxt@2.1.11(magicast@0.5.2):
-    dependencies:
-      '@nuxt/kit': 3.21.1(magicast@0.5.2)
-      dayjs: 1.11.19
-    transitivePeerDependencies:
-      - magicast
-
-  dayjs@1.11.19: {}
 
   db0@0.3.4: {}
 

--- a/nuxt-base-template/pnpm-workspace.yaml
+++ b/nuxt-base-template/pnpm-workspace.yaml
@@ -53,6 +53,20 @@ ignoredOptionalDependencies:
   - '@resvg/resvg-js-win32-ia32-msvc'
   - '@resvg/resvg-js-win32-x64-msvc'
 
+minimumReleaseAgeExclude:
+  - '@lenne.tech/nuxt-extensions@1.7.1'
+  - '@better-auth/core@1.6.13'
+  - '@better-auth/drizzle-adapter@1.6.13'
+  - '@better-auth/kysely-adapter@1.6.13'
+  - '@better-auth/memory-adapter@1.6.13'
+  - '@better-auth/mongo-adapter@1.6.13'
+  - '@better-auth/passkey@1.6.13'
+  - '@better-auth/prisma-adapter@1.6.13'
+  - '@better-auth/telemetry@1.6.13'
+  - better-auth@1.6.13
+  - lint-staged@17.0.7
+  - tinyexec@1.2.4
+
 onlyBuiltDependencies:
   - '@parcel/watcher'
   - esbuild

--- a/nuxt-base-template/tests/e2e/ai.spec.ts
+++ b/nuxt-base-template/tests/e2e/ai.spec.ts
@@ -3,30 +3,41 @@ import { expect, test } from '@nuxt/test-utils/playwright';
 // AI assistant route protection. The conversational flow itself requires a
 // running backend with a configured LLM connection and is covered by the
 // nest-server AI e2e tests; here we verify the frontend wiring + access control.
-test.describe('AI assistant', () => {
-  test('redirects unauthenticated users away from the chat page', async ({ goto, page }) => {
-    await goto('/app/ai', { waitUntil: 'domcontentloaded' });
-    await expect(page).toHaveURL(/\/auth\/login/);
-  });
+//
+// Routes covered (all unauthenticated cases — non-admin and admin cases require
+// authenticated fixtures and live in the broader auth e2e suite):
+//   /app/ai                              (any authenticated user)
+//   /app/settings/ai                     (any authenticated user)
+//   /app/settings/ai-prompts             (any authenticated user)
+//   /app/admin/ai/connections            (admin only)
+//   /app/admin/ai/budgets                (admin only)
+//   /app/admin/ai/interactions           (admin only)
+//   /app/admin/ai/preferences            (admin only)
+//   /app/admin/ai/prompt-hints           (admin only)
+//   /app/admin/ai/slots                  (admin only)
+test.describe('AI assistant — unauthenticated', () => {
+  for (const path of ['/app/ai', '/app/settings/ai', '/app/settings/ai-prompts'] as const) {
+    test(`redirects unauthenticated users away from ${path}`, async ({ goto, page }) => {
+      await goto(path, { waitUntil: 'domcontentloaded' });
+      // Tightened — must land on /auth/login (NOT /app or anywhere else). The previous
+      // `/\/auth\/login|\/app(\/|$)/` regex collapsed unauth-redirect and non-admin-redirect
+      // into a single PASS, hiding regressions in either branch.
+      await expect(page).toHaveURL(/\/auth\/login/);
+    });
+  }
 
-  test('redirects unauthenticated users away from the AI settings page', async ({ goto, page }) => {
-    await goto('/app/settings/ai', { waitUntil: 'domcontentloaded' });
-    await expect(page).toHaveURL(/\/auth\/login/);
-  });
-
-  test('protects the AI admin area (admin-only)', async ({ goto, page }) => {
-    await goto('/app/admin/ai/connections', { waitUntil: 'domcontentloaded' });
-    // admin.global redirects unauthenticated users to login (and non-admins to /app).
-    await expect(page).toHaveURL(/\/auth\/login|\/app(\/|$)/);
-  });
-
-  test('protects the AI prompt-templates admin page (admin-only)', async ({ goto, page }) => {
-    await goto('/app/admin/ai/prompt-templates', { waitUntil: 'domcontentloaded' });
-    await expect(page).toHaveURL(/\/auth\/login|\/app(\/|$)/);
-  });
-
-  test('protects the AI prompt-hints admin page (admin-only)', async ({ goto, page }) => {
-    await goto('/app/admin/ai/prompt-hints', { waitUntil: 'domcontentloaded' });
-    await expect(page).toHaveURL(/\/auth\/login|\/app(\/|$)/);
-  });
+  for (const path of [
+    '/app/admin/ai/connections',
+    '/app/admin/ai/budgets',
+    '/app/admin/ai/interactions',
+    '/app/admin/ai/preferences',
+    '/app/admin/ai/prompt-hints',
+    '/app/admin/ai/slots',
+  ] as const) {
+    test(`redirects unauthenticated users away from admin page ${path}`, async ({ goto, page }) => {
+      await goto(path, { waitUntil: 'domcontentloaded' });
+      // admin.global runs auth check first → unauth users always land on /auth/login.
+      await expect(page).toHaveURL(/\/auth\/login/);
+    });
+  }
 });

--- a/nuxt-base-template/tests/e2e/ai.spec.ts
+++ b/nuxt-base-template/tests/e2e/ai.spec.ts
@@ -19,4 +19,14 @@ test.describe('AI assistant', () => {
     // admin.global redirects unauthenticated users to login (and non-admins to /app).
     await expect(page).toHaveURL(/\/auth\/login|\/app(\/|$)/);
   });
+
+  test('protects the AI prompt-templates admin page (admin-only)', async ({ goto, page }) => {
+    await goto('/app/admin/ai/prompt-templates', { waitUntil: 'domcontentloaded' });
+    await expect(page).toHaveURL(/\/auth\/login|\/app(\/|$)/);
+  });
+
+  test('protects the AI prompt-hints admin page (admin-only)', async ({ goto, page }) => {
+    await goto('/app/admin/ai/prompt-hints', { waitUntil: 'domcontentloaded' });
+    await expect(page).toHaveURL(/\/auth\/login|\/app(\/|$)/);
+  });
 });

--- a/nuxt-base-template/tests/e2e/ai.spec.ts
+++ b/nuxt-base-template/tests/e2e/ai.spec.ts
@@ -1,0 +1,22 @@
+import { expect, test } from '@nuxt/test-utils/playwright';
+
+// AI assistant route protection. The conversational flow itself requires a
+// running backend with a configured LLM connection and is covered by the
+// nest-server AI e2e tests; here we verify the frontend wiring + access control.
+test.describe('AI assistant', () => {
+  test('redirects unauthenticated users away from the chat page', async ({ goto, page }) => {
+    await goto('/app/ai', { waitUntil: 'domcontentloaded' });
+    await expect(page).toHaveURL(/\/auth\/login/);
+  });
+
+  test('redirects unauthenticated users away from the AI settings page', async ({ goto, page }) => {
+    await goto('/app/settings/ai', { waitUntil: 'domcontentloaded' });
+    await expect(page).toHaveURL(/\/auth\/login/);
+  });
+
+  test('protects the AI admin area (admin-only)', async ({ goto, page }) => {
+    await goto('/app/admin/ai/connections', { waitUntil: 'domcontentloaded' });
+    // admin.global redirects unauthenticated users to login (and non-admins to /app).
+    await expect(page).toHaveURL(/\/auth\/login|\/app(\/|$)/);
+  });
+});

--- a/nuxt-base-template/tests/e2e/auth-form-hardening.spec.ts
+++ b/nuxt-base-template/tests/e2e/auth-form-hardening.spec.ts
@@ -1,0 +1,28 @@
+import { expect, test } from '@nuxt/test-utils/playwright';
+
+// Regression guard for the capture-phase preventDefault attached in
+// pages/auth/login.vue + pages/auth/register.vue. A racey/early submit (typed
+// password + Enter before Vue hydration is fully wired) must NOT cause the
+// native form GET that would leak credentials into the URL.
+test.describe('Auth form hardening', () => {
+  test('login page does not native-GET-submit even on a very fast Enter', async ({ goto, page }) => {
+    await goto('/auth/login', { waitUntil: 'domcontentloaded' });
+    // Fill + immediately press Enter — the worst case race window.
+    await page.locator('input[type="email"]').fill('race@test.com');
+    await page.locator('input[type="password"]').fill('SuperSecret123!');
+    await page.locator('input[type="password"]').press('Enter');
+    // No native navigation with credentials in the URL.
+    await page.waitForTimeout(50);
+    await expect(page).not.toHaveURL(/password=/);
+  });
+
+  test('register page does not native-GET-submit either', async ({ goto, page }) => {
+    await goto('/auth/register', { waitUntil: 'domcontentloaded' });
+    await page.locator('input[type="email"]').fill('race-register@test.com');
+    await page.locator('input[type="password"]').first().fill('SuperSecret123!');
+    await page.locator('input[type="password"]').nth(1).fill('SuperSecret123!');
+    await page.locator('input[type="password"]').nth(1).press('Enter');
+    await page.waitForTimeout(50);
+    await expect(page).not.toHaveURL(/password=/);
+  });
+});

--- a/nuxt-base-template/tests/e2e/auth-form-hardening.spec.ts
+++ b/nuxt-base-template/tests/e2e/auth-form-hardening.spec.ts
@@ -1,18 +1,29 @@
 import { expect, test } from '@nuxt/test-utils/playwright';
 
+import { safeFormSubmit } from './helpers/safe-form-submit';
+
 // Regression guard for the capture-phase preventDefault attached in
 // pages/auth/login.vue + pages/auth/register.vue. A racey/early submit (typed
 // password + Enter before Vue hydration is fully wired) must NOT cause the
 // native form GET that would leak credentials into the URL.
+//
+// We use `safeFormSubmit` to dispatch the submit deterministically via the
+// browser API (`form.requestSubmit()`) instead of a timer-based `Enter` +
+// `waitForTimeout` race. The helper waits a short moment for hydration and
+// then triggers the submit so we exercise the SAME code path automation
+// drivers (Chrome DevTools MCP, Playwright) hit in real tests.
 test.describe('Auth form hardening', () => {
-  test('login page does not native-GET-submit even on a very fast Enter', async ({ goto, page }) => {
+  test('login page does not native-GET-submit even on a very fast submit', async ({ goto, page }) => {
     await goto('/auth/login', { waitUntil: 'domcontentloaded' });
-    // Fill + immediately press Enter — the worst case race window.
     await page.locator('input[type="email"]').fill('race@test.com');
     await page.locator('input[type="password"]').fill('SuperSecret123!');
-    await page.locator('input[type="password"]').press('Enter');
-    // No native navigation with credentials in the URL.
-    await page.waitForTimeout(50);
+    // Trigger the submit via the browser API in the same tick the helper would.
+    const result = await page.evaluate(safeFormSubmit, { delayMs: 50 });
+    expect(result.ok, result.reason).toBe(true);
+    // POSITIVE assertion: still on /auth/login (no navigation), credentials
+    // never in the URL. Either failure mode (navigated away OR credentials in
+    // URL) means the capture-phase guard regressed.
+    await expect(page).toHaveURL(/\/auth\/login/);
     await expect(page).not.toHaveURL(/password=/);
   });
 
@@ -21,8 +32,9 @@ test.describe('Auth form hardening', () => {
     await page.locator('input[type="email"]').fill('race-register@test.com');
     await page.locator('input[type="password"]').first().fill('SuperSecret123!');
     await page.locator('input[type="password"]').nth(1).fill('SuperSecret123!');
-    await page.locator('input[type="password"]').nth(1).press('Enter');
-    await page.waitForTimeout(50);
+    const result = await page.evaluate(safeFormSubmit, { delayMs: 50 });
+    expect(result.ok, result.reason).toBe(true);
+    await expect(page).toHaveURL(/\/auth\/register/);
     await expect(page).not.toHaveURL(/password=/);
   });
 });

--- a/nuxt-base-template/tests/e2e/helpers/safe-form-submit.ts
+++ b/nuxt-base-template/tests/e2e/helpers/safe-form-submit.ts
@@ -1,0 +1,47 @@
+/**
+ * Race-safe submit helper for Chrome-DevTools-MCP / Playwright / any synthetic
+ * event driver. See `pages/auth/login.vue` for the underlying race description.
+ *
+ * Why this exists:
+ *   `<UAuthForm>` (Nuxt UI Pro) calls `event.preventDefault()` inside its bubble
+ *   submit-handler. The handler is attached during per-component hydration. A
+ *   synthetic click that fires BEFORE that listener is attached (which happens
+ *   easily with MCP / fast automation) causes the native form GET to run —
+ *   leaking credentials into the URL and bypassing the SPA sign-in flow.
+ *
+ *   The product code now also attaches a capture-phase preventDefault so the
+ *   URL leak cannot happen even in the race window. This helper additionally
+ *   ensures the AUTHENTICATION ACTUALLY HAPPENS in the same case: it waits a
+ *   short moment for hydration, then dispatches the submit event via the
+ *   browser API `form.requestSubmit()`, which is guaranteed to deliver the
+ *   event to every bound listener.
+ *
+ * Usage from a Chrome MCP / Playwright test:
+ *
+ *   await page.evaluate(safeFormSubmit, { formSelector: 'form', delayMs: 200 });
+ *
+ * Or inline as an MCP `evaluate_script`:
+ *
+ *   () => {
+ *     const f = document.querySelector('form');
+ *     if (!f) return { ok: false, reason: 'no form' };
+ *     return new Promise((resolve) => setTimeout(() => {
+ *       f.requestSubmit();
+ *       resolve({ ok: true });
+ *     }, 200));
+ *   }
+ */
+export async function safeFormSubmit(options: { delayMs?: number; formSelector?: string } = {}): Promise<{
+  ok: boolean;
+  reason?: string;
+}> {
+  const selector = options.formSelector ?? 'form';
+  const delayMs = options.delayMs ?? 200;
+  const form = document.querySelector<HTMLFormElement>(selector);
+  if (!form) {
+    return { ok: false, reason: `no form matching "${selector}"` };
+  }
+  await new Promise((r) => setTimeout(r, delayMs));
+  form.requestSubmit();
+  return { ok: true };
+}

--- a/nuxt-base-template/tests/unit/utils/is-admin-user.test.ts
+++ b/nuxt-base-template/tests/unit/utils/is-admin-user.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Guards the dual-shape admin check used by:
+ *   - app/middleware/admin.global.ts (route guard for /app/admin/**)
+ *   - app/layouts/default.vue (admin nav entry)
+ *   - app/pages/app/settings/ai-prompts.vue (mutate-foreign-prompt gate)
+ *
+ * The bug history: the original check only looked at `user.role === 'admin'`
+ * (Better Auth singular). Real nest-server projections carry `roles: string[]`,
+ * so admins were redirected from /app/admin/** and the nav never appeared.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { isAdminUser } from '../../../app/utils/is-admin-user';
+
+describe('isAdminUser', () => {
+  it('returns false when user is null', () => {
+    expect(isAdminUser(null)).toBe(false);
+  });
+
+  it('returns false when user is undefined', () => {
+    expect(isAdminUser(undefined)).toBe(false);
+  });
+
+  it('returns true when role === "admin" (Better Auth singular shape)', () => {
+    expect(isAdminUser({ role: 'admin' })).toBe(true);
+  });
+
+  it('returns true when roles contains "admin" (nest-server array shape)', () => {
+    expect(isAdminUser({ roles: ['admin'] })).toBe(true);
+  });
+
+  it('returns true when both shapes are set and either matches', () => {
+    expect(isAdminUser({ role: 'admin', roles: ['user'] })).toBe(true);
+    expect(isAdminUser({ role: 'user', roles: ['admin'] })).toBe(true);
+  });
+
+  it('returns false for a non-admin user', () => {
+    expect(isAdminUser({ role: 'user' })).toBe(false);
+    expect(isAdminUser({ roles: ['user', 'editor'] })).toBe(false);
+    expect(isAdminUser({})).toBe(false);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-nuxt-base",
-  "version": "2.7.2",
+  "version": "2.8.0",
   "description": "Starter to generate a configured environment with VueJS, Nuxt, Tailwind, Linting, Unit Tests, Playwright etc.",
   "license": "MIT",
   "author": "lenne.Tech GmbH",


### PR DESCRIPTION
# AI Assistant UI + Auth Hardening

A focused release that ships the **client-side surface for the `@lenne.tech/nest-server` AI module** plus a security-relevant **login/register hardening**, together with the upgrade to `@lenne.tech/nuxt-extensions 1.7.1` and the documentation needed for adopters to take it.

## What's new

### AI Assistant — chat + admin (eight new routes)

- `/app/ai` — streaming chat with confirmation flow, token bar (click-popover with all numbers), context-window indicator, prompt picker, placeholder helper sidebar.
- `/app/settings/ai` — personal default connection + token usage.
- `/app/settings/ai-prompts` — CRUD for re-usable prompts ("Vorlagen"), private or tenant-shared.
- `/app/admin/ai/{connections,preferences,budgets,interactions,slots,prompt-hints}` — full admin surface: connection CRUD with capability auto-detection (OpenAI-compatible or Claude CLI), per-tenant/user default connections, token & request budget limits, prompt audit log, tenant-scoped slot overrides/reset/soft-delete on top of the 10 framework defaults, and a learned-hint approval workflow.
- `/app/admin` — admin dashboard card grid.

### Auth-form hardening — closes a credential-leak race

Capture-phase `preventDefault` attached on `login.vue` and `register.vue` blocks the native form GET that could land the typed password in the URL while Vue's bubble handler is still being hydrated. Regression test (`auth-form-hardening.spec.ts`) and a synthetic-submit helper (`safe-form-submit.ts`) are shipped to keep it that way.

### Quality

- Canonical `isAdminUser` utility (auto-imported, six-case Vitest guard) replaces the three inline duplicates of the dual-shape `role`/`roles[]` admin check.
- `AiChat.vue` scroll-watcher reduced from O(n·m) per SSE token to O(1); message history capped at 100 to prevent unbounded growth in long-lived chat tabs.
- `definePageMeta({ ssr: false })` on all nine AI pages — they are authenticated SPAs and SSR was emitting empty skeleton HTML.

## For adopters

- **Migration guide:** [`migration-guides/2.8.0-ai-module.md`](../migration-guides/2.8.0-ai-module.md) — covers opt-in/opt-out (`ltExtensions.ai.enabled`), required nest-server `11.26.0+` backend pairing with the `/ai/*` route inventory, and — **mandatory for forks with customized auth pages** — the capture-phase `preventDefault` port.
- **Updated docs:** `README.md` (full AI route + component inventory, opt-out path, project structure), `CLAUDE.md` (new AI Module, Admin Gating, and `minimumReleaseAgeExclude` sections).
- **Opt-out** is one config flag: set `ltExtensions.ai.enabled: false` and delete the AI directories. The auth hardening and `isAdminUser` utility stay regardless — they're pure security/quality wins.
